### PR TITLE
fix: enforce global module toggles across the bot fleet and dashboards

### DIFF
--- a/web/app/composables/useServerSettings.ts
+++ b/web/app/composables/useServerSettings.ts
@@ -281,7 +281,12 @@ export function useServerSettings(guildId: string) {
   // ── Initialization ──
   const fetchModules = async () => {
     try {
-      state.value.modules = await $fetch<ModuleDoc[]>("/api/modules");
+      const all = await $fetch<ModuleDoc[]>("/api/modules");
+      // Hide modules an admin has disabled globally: a fleet-wide kill switch
+      // should remove them from every server's dashboard, not just make the
+      // per-server toggle non-functional. `enabled` here is the global flag
+      // from the modules table (per-server state lives in guildConfigs).
+      state.value.modules = all.filter((m) => m.enabled);
     } catch (error) {
       console.error("Error fetching modules:", error);
     }

--- a/web/server/api/modules/[name].patch.ts
+++ b/web/server/api/modules/[name].patch.ts
@@ -8,6 +8,7 @@
  */
 import { getRepos } from "../../utils/db";
 import { requireBotAdmin } from "../../utils/session";
+import { CHANNEL_MODULES, publish } from "../../utils/eventbus";
 
 export default defineEventHandler(async (event) => {
   await requireBotAdmin(event);
@@ -35,6 +36,10 @@ export default defineEventHandler(async (event) => {
 
   try {
     await repos.modules.setEnabled(name, body.enabled);
+    // Notify the running bot fleet so every shard re-reads the modules table
+    // and refreshes its in-memory enabled set. Without this the toggle only
+    // takes effect on the next bot restart. No-op when Redis is unconfigured.
+    await publish(CHANNEL_MODULES, { kind: "changed" });
     return { success: true };
   } catch (error: any) {
     console.error(

--- a/web/server/utils/eventbus.ts
+++ b/web/server/utils/eventbus.ts
@@ -14,6 +14,7 @@
  * Channel names are duplicated from bot/EventBus.ts because this package
  * doesn't import from bot. Keep them in sync.
  */
+import { randomUUID } from "node:crypto";
 import Redis, { type RedisOptions } from "ioredis";
 
 export const CHANNEL_LOGS = "modus:realtime:logs";
@@ -39,6 +40,9 @@ interface Clients {
 let clients: Clients | null = null;
 const handlers = new Map<string, Set<Handler>>();
 const subscribedChannels = new Set<string>();
+
+/** Stable per-process origin so bot subscribers can ignore our own publishes. */
+const originId = `web:${randomUUID()}`;
 
 function getClients(): Clients | null {
   if (clients) return clients;
@@ -100,6 +104,24 @@ function getClients(): Clients | null {
 /** True when REDIS_URL is configured. SSE endpoints early-return when not. */
 export function isRealtimeAvailable(): boolean {
   return !!process.env.REDIS_URL;
+}
+
+/**
+ * Publish a message to a channel, wrapped in the same `{ origin, ts, payload }`
+ * envelope the bot's EventBus emits and subscribes to (bot/EventBus.ts). Used by
+ * dashboard write routes to notify the running bot fleet of changes (e.g. an
+ * admin toggling a module's global enabled flag). No-op when REDIS_URL is unset —
+ * in that case the bot only picks up changes on restart.
+ */
+export async function publish<T = unknown>(
+  channel: string,
+  payload: T,
+): Promise<void> {
+  const c = getClients();
+  if (!c) return;
+
+  const envelope: Envelope<T> = { origin: originId, ts: Date.now(), payload };
+  await c.primary.publish(channel, JSON.stringify(envelope));
 }
 
 /**


### PR DESCRIPTION
## Problem

When a bot admin toggled a module **off** in the admin dashboard, it wasn't actually disabled for anyone — the module kept working, and it still appeared (with a functional-looking toggle) in every server admin's management dashboard.

Two gaps caused this:

1. **The running bot never found out.** `PATCH /api/modules/:name` wrote the `enabled` flag to Postgres, but `ModuleManager`'s global enabled set has no TTL and refreshes only at boot or on a `CHANNEL_MODULES` Redis event — and the web side never published that event (its eventbus was subscribe-only). So a disabled module stayed fully usable until the bot process restarted.
2. **Server dashboards still showed it.** The per-server module grid renders `GET /api/modules` (`listAll()`), which returns every module regardless of the global flag, so server admins saw a card + per-server toggle that silently did nothing.

(Per-guild toggles already worked because that path has a 60s TTL cache; only the global path was broken.)

## Changes

- **`feat(web)`** — Add a `publish()` helper to the Nitro eventbus (previously subscribe-only), wrapping payloads in the same `{ origin, ts, payload }` envelope the bot's `EventBus` consumes.
- **`fix(api)`** — After `setEnabled`, publish `CHANNEL_MODULES` so every shard re-reads the modules table and enforces the toggle within moments. The bot then replies "This module is currently disabled globally." for commands, buttons, select menus, and modals.
- **`fix(web)`** — Filter `useServerSettings.fetchModules` to globally-enabled modules only, so a fleet-wide disable removes the module from every server dashboard. The admin page fetches independently and still lists disabled modules to re-enable them.

## Notes / caveats

- **Redis-dependent**, consistent with the existing module hot-reload design: without `REDIS_URL`, the bot still only picks up global toggles on restart.
- **Server dashboard hides on next fetch**, not live: if an admin disables a module while a server admin has the page open, the card disappears on their next refresh/navigation. Wiring the dashboard to the existing `modules` SSE channel for instant updates is a possible follow-up.
- The globally-disabled module's slash command still appears in Discord's global command list but returns the disabled message (per decision during review — full command removal was intentionally out of scope).

## Testing

`nuxt typecheck` introduces no new errors in the touched files (pre-existing unrelated errors remain). No test runner is wired up in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)