### PR TITLE
feat(ai): append-model system prompt + AI dashboard reorganization

### DIFF
--- a/bot/lib/aiPrompt.ts
+++ b/bot/lib/aiPrompt.ts
@@ -1,0 +1,81 @@
+// ── AI System Prompt Composition ───────────────────────────────────
+// The effective system prompt is layered:
+//   CORE_SYSTEM_PROMPT            (immutable rules — always applied)
+//   + guild personality/tone      (appended; owned by the dashboard field)
+//   + TOOL_USE_..._APPENDIX        (appended when tool use is enabled)
+// The guild field APPENDS to the core; it never replaces it.
+
+/** Identity + behavior rules. No personality — tone lives in the guild field. */
+export const CORE_SYSTEM_PROMPT = `You are Modus, a helpful AI assistant built into a Discord bot. \
+Be as concise as you can WHILE still giving a COMPLETE answer — always include the specific \
+facts, numbers, and details the user actually asked for (e.g. the current temperature, the exact price, \
+the actual result) rather than a vague summary that leaves them out. Don't pad, but don't cut the answer short either. \
+You can help with questions, have casual conversations, and assist server members. \
+Do not pretend to have capabilities you don't have. Stay on topic and be helpful.`;
+
+/** Default tone. Seeds the dashboard field and is used when a guild leaves it blank. */
+export const DEFAULT_PERSONALITY =
+  `You have a witty, upbeat personality and keep a conversational, friendly tone.`;
+
+/** Appended only when tool use is enabled. */
+export const TOOL_USE_SYSTEM_PROMPT_APPENDIX = `You also have direct control over the music player for this Discord server. \
+When a user asks you to play, skip, stop, pause, resume, adjust volume, view the queue, or shuffle, \
+use the appropriate music tool rather than describing what to do. \
+Always execute the action and report what you did.
+
+You can also search the web for current information using the web_search tool. \
+Use it when the user asks about recent events, news, live scores, current prices, weather, or anything \
+that requires up-to-date information you might not have. \
+Do NOT use web_search for general knowledge questions you can already answer accurately.
+
+IMPORTANT — when tools are involved, ACT instead of narrating:
+- Never tell the user you are "about to" search, that you'll "look it up", "dig that up", or "try to find" something. \
+Do not describe your plan. Just call the tool immediately and silently.
+- After a tool returns, reply to the user with the actual answer to their question, using the data from the results.
+- If the first results don't clearly contain the answer, call web_search AGAIN with a better query \
+(for example add the country/region, or the phrase "current conditions" / "right now") before you respond. \
+Try at least twice before telling the user you couldn't find it.
+- Your reply to the user must be a finished, complete answer — never a promise to do something next.`;
+
+/**
+ * Full default prompts shipped BEFORE the append-model change. Guilds that never
+ * customized their prompt have one of these stored verbatim. Treated as "unset"
+ * so we don't re-append the old identity text or its "2-4 sentences" instruction.
+ * Extend this list if older historical defaults surface.
+ */
+export const LEGACY_DEFAULT_PROMPTS: string[] = [
+  `You are Modus, a helpful and friendly AI assistant built into a Discord bot. \
+You have a witty, upbeat personality. Keep responses concise (2-4 sentences max) and conversational. \
+You can help with questions, have casual conversations, and assist server members. \
+Do not pretend to have capabilities you don't have. Stay on topic and be helpful.`,
+];
+
+function normalizeWhitespace(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Resolve the guild's stored value into the tone text to append.
+ * - empty OR a known legacy default → DEFAULT_PERSONALITY
+ * - anything else → the trimmed custom text
+ */
+export function resolvePersonality(raw: string | null | undefined): string {
+  const normalized = normalizeWhitespace(raw ?? "");
+  if (!normalized) return DEFAULT_PERSONALITY;
+  for (const legacy of LEGACY_DEFAULT_PROMPTS) {
+    if (normalizeWhitespace(legacy) === normalized) return DEFAULT_PERSONALITY;
+  }
+  return (raw ?? "").trim();
+}
+
+/** Compose the effective system prompt: core + tone + (optional) tool appendix. */
+export function buildSystemPrompt(
+  rawPersonality: string | null | undefined,
+  toolUseEnabled: boolean,
+): string {
+  let prompt = CORE_SYSTEM_PROMPT;
+  const tone = resolvePersonality(rawPersonality);
+  if (tone) prompt += "\n\n" + tone;
+  if (toolUseEnabled) prompt += "\n\n" + TOOL_USE_SYSTEM_PROMPT_APPENDIX;
+  return prompt;
+}

--- a/bot/lib/schemas.ts
+++ b/bot/lib/schemas.ts
@@ -173,7 +173,7 @@ export const AISettingsSchema = z.object({
   aiBaseUrl: z.string().default(""),
   systemPrompt: z.string().default(""),
   maxInputTokens: z.number().default(500),
-  maxOutputTokens: z.number().default(300),
+  maxOutputTokens: z.number().default(512),
   rateLimitSeconds: z.number().default(60),
   respondToDMs: z.boolean().default(false),
   toolUseEnabled: z.boolean().default(false),

--- a/bot/lib/schemas.ts
+++ b/bot/lib/schemas.ts
@@ -171,7 +171,9 @@ export const AISettingsSchema = z.object({
   aiApiKey: z.string().default(""),
   aiModel: z.string().default("llama-3.3-70b-versatile"),
   aiBaseUrl: z.string().default(""),
-  systemPrompt: z.string().default(""),
+  // Clamp (not .max) — parseSettings fails the whole object on a rejected field,
+  // which would wipe all AI settings for a guild with an over-long stored prompt.
+  systemPrompt: z.string().default("").transform((s) => s.slice(0, 2000)),
   maxInputTokens: z.number().default(500),
   maxOutputTokens: z.number().default(512),
   rateLimitSeconds: z.number().default(60),

--- a/bot/modules/ai.ts
+++ b/bot/modules/ai.ts
@@ -182,44 +182,29 @@ function buildContextMessages(
 }
 
 // ── Cost Estimation ────────────────────────────────────────────────
-// Approximate per-million-token pricing (input / output) in USD
-
-const MODEL_PRICING: Record<string, { input: number; output: number }> = {
-  // OpenAI
-  "gpt-4o": { input: 2.5, output: 10.0 },
-  "gpt-4o-mini": { input: 0.15, output: 0.6 },
-  "gpt-4-turbo": { input: 10.0, output: 30.0 },
-  "gpt-3.5-turbo": { input: 0.5, output: 1.5 },
-  // Anthropic
-  "claude-opus-4": { input: 15.0, output: 75.0 },
-  "claude-sonnet-4": { input: 3.0, output: 15.0 },
-  "claude-haiku-3-5": { input: 0.8, output: 4.0 },
-  "claude-3-5-sonnet": { input: 3.0, output: 15.0 },
-  "claude-3-5-haiku": { input: 0.8, output: 4.0 },
-  // Google Gemini
-  "gemini-1.5-flash": { input: 0.075, output: 0.3 },
-  "gemini-1.5-pro": { input: 3.5, output: 10.5 },
-  "gemini-2.0-flash": { input: 0.1, output: 0.4 },
-  // Groq (free tier — cost is ~0)
-  "llama-3.3-70b-versatile": { input: 0.0, output: 0.0 },
-  "llama-3.1-8b-instant": { input: 0.0, output: 0.0 },
-  "mixtral-8x7b-32768": { input: 0.0, output: 0.0 },
-};
+// `estimated_cost` is a rough analytics figure, not billing. Rather than
+// hardcode a price catalog that rots as models and prices change, we read
+// optional per-million-token rates from the environment:
+//
+//   AI_PRICE_INPUT_PER_MTOK   USD per 1M input tokens
+//   AI_PRICE_OUTPUT_PER_MTOK  USD per 1M output tokens
+//
+// If neither is set (e.g. a free-tier provider like Groq), we log exact token
+// counts only and leave estimated_cost NULL. Token counts are always accurate;
+// the dollar figure is best-effort and opt-in.
 
 function estimateCost(
-  model: string,
   inputTokens: number,
   outputTokens: number,
-): number {
-  // Exact match → prefix match → default to 0
-  let pricing = MODEL_PRICING[model];
-  if (!pricing) {
-    const prefix = Object.keys(MODEL_PRICING).find((k) => model.startsWith(k));
-    pricing = prefix ? MODEL_PRICING[prefix] : { input: 0, output: 0 };
-  }
+): number | undefined {
+  const inRate = Number(process.env.AI_PRICE_INPUT_PER_MTOK);
+  const outRate = Number(process.env.AI_PRICE_OUTPUT_PER_MTOK);
+  const haveIn = Number.isFinite(inRate);
+  const haveOut = Number.isFinite(outRate);
+  if (!haveIn && !haveOut) return undefined;
   return (
-    (inputTokens / 1_000_000) * pricing.input +
-    (outputTokens / 1_000_000) * pricing.output
+    (haveIn ? (inputTokens / 1_000_000) * inRate : 0) +
+    (haveOut ? (outputTokens / 1_000_000) * outRate : 0)
   );
 }
 
@@ -725,7 +710,10 @@ function getCooldownRemaining(
 // ── Defaults ───────────────────────────────────────────────────────
 
 const DEFAULT_SYSTEM_PROMPT = `You are Modus, a helpful and friendly AI assistant built into a Discord bot. \
-You have a witty, upbeat personality. Keep responses concise (2-4 sentences max) and conversational. \
+You have a witty, upbeat personality and keep a conversational tone. \
+Be as concise as you can WHILE still giving a COMPLETE answer — always include the specific \
+facts, numbers, and details the user actually asked for (e.g. the current temperature, the exact price, \
+the actual result) rather than a vague summary that leaves them out. Don't pad, but don't cut the answer short either. \
 You can help with questions, have casual conversations, and assist server members. \
 Do not pretend to have capabilities you don't have. Stay on topic and be helpful.`;
 
@@ -737,9 +725,18 @@ use the appropriate music tool rather than describing what to do. \
 Always execute the action and report what you did.
 
 You can also search the web for current information using the web_search tool. \
-Use it when the user asks about recent events, news, live scores, current prices, or anything \
+Use it when the user asks about recent events, news, live scores, current prices, weather, or anything \
 that requires up-to-date information you might not have. \
-Do NOT use web_search for general knowledge questions you can already answer accurately.`;
+Do NOT use web_search for general knowledge questions you can already answer accurately.
+
+IMPORTANT — when tools are involved, ACT instead of narrating:
+- Never tell the user you are "about to" search, that you'll "look it up", "dig that up", or "try to find" something. \
+Do not describe your plan. Just call the tool immediately and silently.
+- After a tool returns, reply to the user with the actual answer to their question, using the data from the results.
+- If the first results don't clearly contain the answer, call web_search AGAIN with a better query \
+(for example add the country/region, or the phrase "current conditions" / "right now") before you respond. \
+Try at least twice before telling the user you couldn't find it.
+- Your reply to the user must be a finished, complete answer — never a promise to do something next.`;
 
 const DEFAULT_SETTINGS: Required<AIModuleSettings> = {
   aiProvider: "Groq",
@@ -748,7 +745,7 @@ const DEFAULT_SETTINGS: Required<AIModuleSettings> = {
   aiBaseUrl: "",
   systemPrompt: DEFAULT_SYSTEM_PROMPT,
   maxInputTokens: 500,
-  maxOutputTokens: 300,
+  maxOutputTokens: 512,
   rateLimitSeconds: 60,
   respondToDMs: false,
   toolUseEnabled: false,
@@ -887,7 +884,7 @@ export function registerAIEvents(moduleManager: ModuleManager) {
           return;
         }
 
-        // 1️⃣ Try admin-set global config from Appwrite
+        // 1️⃣ Try admin-set global config (Postgres, via guild_configs)
         const globalConfig = await db.getGlobalAIConfig();
 
         if (globalConfig?.aiApiKey) {
@@ -927,7 +924,7 @@ export function registerAIEvents(moduleManager: ModuleManager) {
         // Enforce shared-key token/rate limits regardless of guild settings
         settings.rateLimitSeconds = 60;
         settings.maxInputTokens = 500;
-        settings.maxOutputTokens = 300;
+        settings.maxOutputTokens = 512;
       }
 
       // ─ Rate limit check ─────────────────────────────────────────
@@ -1128,11 +1125,7 @@ export function registerAIEvents(moduleManager: ModuleManager) {
       }
 
       // ─ Log usage ─────────────────────────────────────────────────
-      const cost = estimateCost(
-        settings.aiModel,
-        totalInputTokens,
-        totalOutputTokens,
-      );
+      const cost = estimateCost(totalInputTokens, totalOutputTokens);
 
       await db.logAIUsage({
         guildId,
@@ -1142,7 +1135,7 @@ export function registerAIEvents(moduleManager: ModuleManager) {
         input_tokens: totalInputTokens,
         output_tokens: totalOutputTokens,
         total_tokens: totalInputTokens + totalOutputTokens,
-        estimated_cost: cost,
+        ...(cost !== undefined ? { estimated_cost: cost } : {}),
         action,
         key_source: keySource,
       });

--- a/bot/modules/ai.ts
+++ b/bot/modules/ai.ts
@@ -11,6 +11,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { BotModule, ModuleManager } from "../ModuleManager";
 import { AISettingsSchema } from "../lib/schemas";
 import { parseSettings } from "../lib/validateSettings";
+import { buildSystemPrompt } from "../lib/aiPrompt";
 import {
   musicPlay,
   musicSkip,
@@ -709,41 +710,12 @@ function getCooldownRemaining(
 
 // ── Defaults ───────────────────────────────────────────────────────
 
-const DEFAULT_SYSTEM_PROMPT = `You are Modus, a helpful and friendly AI assistant built into a Discord bot. \
-You have a witty, upbeat personality and keep a conversational tone. \
-Be as concise as you can WHILE still giving a COMPLETE answer — always include the specific \
-facts, numbers, and details the user actually asked for (e.g. the current temperature, the exact price, \
-the actual result) rather than a vague summary that leaves them out. Don't pad, but don't cut the answer short either. \
-You can help with questions, have casual conversations, and assist server members. \
-Do not pretend to have capabilities you don't have. Stay on topic and be helpful.`;
-
-const TOOL_USE_SYSTEM_PROMPT_APPENDIX = `
-
-You also have direct control over the music player for this Discord server. \
-When a user asks you to play, skip, stop, pause, resume, adjust volume, view the queue, or shuffle, \
-use the appropriate music tool rather than describing what to do. \
-Always execute the action and report what you did.
-
-You can also search the web for current information using the web_search tool. \
-Use it when the user asks about recent events, news, live scores, current prices, weather, or anything \
-that requires up-to-date information you might not have. \
-Do NOT use web_search for general knowledge questions you can already answer accurately.
-
-IMPORTANT — when tools are involved, ACT instead of narrating:
-- Never tell the user you are "about to" search, that you'll "look it up", "dig that up", or "try to find" something. \
-Do not describe your plan. Just call the tool immediately and silently.
-- After a tool returns, reply to the user with the actual answer to their question, using the data from the results.
-- If the first results don't clearly contain the answer, call web_search AGAIN with a better query \
-(for example add the country/region, or the phrase "current conditions" / "right now") before you respond. \
-Try at least twice before telling the user you couldn't find it.
-- Your reply to the user must be a finished, complete answer — never a promise to do something next.`;
-
 const DEFAULT_SETTINGS: Required<AIModuleSettings> = {
   aiProvider: "Groq",
   aiApiKey: "",
   aiModel: "llama-3.3-70b-versatile",
   aiBaseUrl: "",
-  systemPrompt: DEFAULT_SYSTEM_PROMPT,
+  systemPrompt: "",
   maxInputTokens: 500,
   maxOutputTokens: 512,
   rateLimitSeconds: 60,
@@ -970,14 +942,11 @@ export function registerAIEvents(moduleManager: ModuleManager) {
       }
 
       // ─ Build effective system prompt ─────────────────────────────
-      // Guard: fall back to default prompt if the guild saved an empty string
-      let effectiveSystemPrompt =
-        settings.systemPrompt?.trim() || DEFAULT_SYSTEM_PROMPT;
-
-      // Append music tool hint when tool use is enabled
-      if (settings.toolUseEnabled) {
-        effectiveSystemPrompt += TOOL_USE_SYSTEM_PROMPT_APPENDIX;
-      }
+      // Core rules (always) + guild personality (appended) + tool appendix.
+      const effectiveSystemPrompt = buildSystemPrompt(
+        settings.systemPrompt,
+        settings.toolUseEnabled,
+      );
 
       // ─ Build messages array with conversation context ────────────
       const channelId = message.channel.id;

--- a/bot/modules/ai.ts
+++ b/bot/modules/ai.ts
@@ -194,18 +194,25 @@ function buildContextMessages(
 // counts only and leave estimated_cost NULL. Token counts are always accurate;
 // the dollar figure is best-effort and opt-in.
 
+function envRate(name: string): number | undefined {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : undefined;
+}
+
 function estimateCost(
   inputTokens: number,
   outputTokens: number,
 ): number | undefined {
-  const inRate = Number(process.env.AI_PRICE_INPUT_PER_MTOK);
-  const outRate = Number(process.env.AI_PRICE_OUTPUT_PER_MTOK);
-  const haveIn = Number.isFinite(inRate);
-  const haveOut = Number.isFinite(outRate);
+  const inRate = envRate("AI_PRICE_INPUT_PER_MTOK");
+  const outRate = envRate("AI_PRICE_OUTPUT_PER_MTOK");
+  const haveIn = inRate !== undefined;
+  const haveOut = outRate !== undefined;
   if (!haveIn && !haveOut) return undefined;
   return (
-    (haveIn ? (inputTokens / 1_000_000) * inRate : 0) +
-    (haveOut ? (outputTokens / 1_000_000) * outRate : 0)
+    (haveIn ? (inputTokens / 1_000_000) * inRate! : 0) +
+    (haveOut ? (outputTokens / 1_000_000) * outRate! : 0)
   );
 }
 

--- a/web/app/pages/dashboard/server/[guild_id]/modules/ai.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/ai.vue
@@ -182,7 +182,7 @@
           </div>
         </template>
 
-        <UFormField label="Personality & Instructions">
+        <UFormField>
           <UTextarea
             v-model="settings.systemPrompt"
             :rows="6"
@@ -613,7 +613,7 @@ const settings = ref({
   aiBaseUrl: "",
   systemPrompt: DEFAULT_PERSONALITY,
   maxInputTokens: 500,
-  maxOutputTokens: 300,
+  maxOutputTokens: 512,
   rateLimitSeconds: 60,
   respondToDMs: false,
   toolUseEnabled: false,

--- a/web/app/pages/dashboard/server/[guild_id]/modules/ai.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/ai.vue
@@ -69,12 +69,12 @@
     />
 
     <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
-      <!-- ── Card 1: Provider Configuration ───────────────────────── -->
+      <!-- ── Card 1: Provider & Model ─────────────────────────────── -->
       <UCard class="xl:col-span-2">
         <template #header>
           <div class="flex items-center gap-2">
             <UIcon name="i-heroicons-key" class="w-5 h-5 text-violet-400" />
-            <h2 class="font-semibold text-base">Provider Configuration</h2>
+            <h2 class="font-semibold text-base">Provider & Model</h2>
           </div>
         </template>
 
@@ -221,7 +221,45 @@
         </UCollapsible>
       </UCard>
 
-      <!-- ── Card 3: Conversation Memory ──────────────────────────── -->
+      <!-- ── Card 3: Behavior & Features ──────────────────────────── -->
+      <UCard>
+        <template #header>
+          <div class="flex items-center gap-2">
+            <UIcon name="i-heroicons-sparkles" class="w-5 h-5 text-fuchsia-400" />
+            <h2 class="font-semibold text-base">Behavior & Features</h2>
+          </div>
+        </template>
+
+        <div class="space-y-5">
+          <UFormField
+            label="DM Responses"
+            hint="Allow the bot to respond to @mentions in DMs."
+          >
+            <USwitch v-model="settings.respondToDMs" label="Respond in DMs" />
+          </UFormField>
+
+          <UFormField
+            label="Tool Use — Music & Web Search"
+            hint="Let the AI control music (play/skip/pause/queue) and search the web on @mention."
+          >
+            <USwitch
+              v-model="settings.toolUseEnabled"
+              label="Enable tool use"
+            />
+          </UFormField>
+
+          <UAlert
+            v-if="settings.toolUseEnabled && toolUseWarning"
+            color="warning"
+            variant="soft"
+            icon="i-heroicons-exclamation-triangle"
+            :title="toolUseWarning"
+            description="Tool use works best with 70B+ models. Try llama-3.3-70b-versatile (Groq, free) or gpt-4o-mini (OpenAI) for reliable results."
+          />
+        </div>
+      </UCard>
+
+      <!-- ── Card 4: Conversation Memory ──────────────────────────── -->
       <UCard>
         <template #header>
           <div class="flex items-center gap-2">
@@ -290,7 +328,7 @@
         </div>
       </UCard>
 
-      <!-- ── Card 4: Rate Limiting & Limits ────────────────────────── -->
+      <!-- ── Card 5: Limits & Rate Limiting ────────────────────────── -->
       <UCard>
         <template #header>
           <div class="flex items-center gap-2">
@@ -362,38 +400,11 @@
               </span>
             </div>
           </UFormField>
-
-          <UFormField
-            label="DM Responses"
-            hint="Allow the bot to respond to @mentions in DMs."
-          >
-            <USwitch v-model="settings.respondToDMs" label="Respond in DMs" />
-          </UFormField>
-
-          <UFormField
-            label="Tool Use — Music Control"
-            hint="Allow the AI to play, skip, pause, and control music on @mention commands."
-          >
-            <USwitch
-              v-model="settings.toolUseEnabled"
-              label="Enable music tool use"
-            />
-          </UFormField>
-
-          <!-- Low-capability model warning -->
-          <UAlert
-            v-if="settings.toolUseEnabled && toolUseWarning"
-            color="warning"
-            variant="soft"
-            icon="i-heroicons-exclamation-triangle"
-            :title="toolUseWarning"
-            description="Tool use works best with 70B+ models. Try llama-3.3-70b-versatile (Groq, free) or gpt-4o-mini (OpenAI) for reliable results."
-          />
         </div>
       </UCard>
     </div>
 
-    <!-- ── Card 4: Usage & Spending ──────────────────────────────────── -->
+    <!-- ── Card 6: Usage & Spending ──────────────────────────────────── -->
     <UCard>
       <template #header>
         <div class="flex items-center justify-between">

--- a/web/app/pages/dashboard/server/[guild_id]/modules/ai.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/ai.vue
@@ -160,7 +160,7 @@
         </div>
       </UCard>
 
-      <!-- ── Card 2: System Prompt ─────────────────────────────────── -->
+      <!-- ── Card 2: Personality & Instructions ───────────────────── -->
       <UCard>
         <template #header>
           <div class="flex items-center justify-between">
@@ -169,9 +169,7 @@
                 name="i-heroicons-chat-bubble-left-ellipsis"
                 class="w-5 h-5 text-blue-400"
               />
-              <h2 class="font-semibold text-base">
-                Personality & System Prompt
-              </h2>
+              <h2 class="font-semibold text-base">Personality &amp; Instructions</h2>
             </div>
             <UButton
               size="xs"
@@ -184,24 +182,43 @@
           </div>
         </template>
 
-        <UFormField label="System Prompt">
+        <UFormField label="Personality & Instructions">
           <UTextarea
             v-model="settings.systemPrompt"
-            :rows="8"
-            placeholder="You are Modus, a helpful Discord bot assistant..."
+            :rows="6"
+            :maxlength="2000"
+            placeholder="Describe the tone and any extra instructions…"
             class="font-mono text-sm w-full"
             resize
           />
         </UFormField>
 
         <div class="mt-2 flex justify-between items-center">
-          <span class="text-xs text-gray-500">
-            {{ settings.systemPrompt?.length ?? 0 }} characters
+          <span
+            class="text-xs"
+            :class="(settings.systemPrompt?.length ?? 0) > 1800 ? 'text-amber-400' : 'text-gray-500'"
+          >
+            {{ settings.systemPrompt?.length ?? 0 }} / 2000 characters
           </span>
           <span class="text-xs text-gray-500">
-            This prompt sets the bot's personality and behavior.
+            Added on top of Modus's built-in behavior. Leave blank for the default friendly tone.
           </span>
         </div>
+
+        <UCollapsible class="mt-4">
+          <UButton
+            variant="ghost"
+            color="neutral"
+            size="xs"
+            trailing-icon="i-heroicons-chevron-down"
+            label="Built-in behavior (always applied)"
+          />
+          <template #content>
+            <p class="text-xs text-gray-400 leading-relaxed bg-gray-900/40 rounded-lg p-3 mt-2">
+              {{ CORE_BEHAVIOR_PREVIEW }}
+            </p>
+          </template>
+        </UCollapsible>
       </UCard>
 
       <!-- ── Card 3: Conversation Memory ──────────────────────────── -->
@@ -563,17 +580,27 @@ const savingEnabled = ref(false);
 const saving = ref(false);
 const isPremium = ref(false);
 
-const DEFAULT_SYSTEM_PROMPT = `You are Modus, a helpful and friendly AI assistant built into a Discord bot. 
-You have a witty, upbeat personality. Keep responses concise (2-4 sentences max) and conversational. 
-You can help with questions, have casual conversations, and assist server members. 
-Do not pretend to have capabilities you don't have. Stay on topic and be helpful.`;
+const DEFAULT_PERSONALITY = `You have a witty, upbeat personality and keep a conversational, friendly tone.`;
+
+// Full default prompts shipped before the append-model change. If a guild has one
+// stored verbatim, show the tone default instead of the old wall of text.
+const LEGACY_DEFAULT_PROMPTS = [
+  `You are Modus, a helpful and friendly AI assistant built into a Discord bot. \nYou have a witty, upbeat personality. Keep responses concise (2-4 sentences max) and conversational. \nYou can help with questions, have casual conversations, and assist server members. \nDo not pretend to have capabilities you don't have. Stay on topic and be helpful.`,
+];
+
+// Read-only preview of the bot-owned rules the personality is appended to.
+const CORE_BEHAVIOR_PREVIEW = `You are Modus, a helpful AI assistant built into a Discord bot. Always give a complete answer — include the specific facts, numbers, and details asked for. When tools are enabled, act instead of narrating (never say "let me look that up" — just do it, then answer). Never pretend to have capabilities you don't have.`;
+
+function normalizeWhitespace(s: string | undefined | null) {
+  return (s ?? "").replace(/\s+/g, " ").trim();
+}
 
 const settings = ref({
   aiProvider: "Groq" as string,
   aiApiKey: "",
   aiModel: "llama-3.3-70b-versatile",
   aiBaseUrl: "",
-  systemPrompt: DEFAULT_SYSTEM_PROMPT,
+  systemPrompt: DEFAULT_PERSONALITY,
   maxInputTokens: 500,
   maxOutputTokens: 300,
   rateLimitSeconds: 60,
@@ -587,7 +614,6 @@ const settings = ref({
 const availableModels = ref<string[]>([
   "llama-3.3-70b-versatile",
   "llama-3.1-8b-instant",
-  "mixtral-8x7b-32768",
 ]);
 const modelsLoading = ref(false);
 const modelsWarning = ref("");
@@ -665,7 +691,6 @@ const SMALL_MODELS = [
   "llama-3.2-3b",
   "gemma-7b",
   "gemma2-9b",
-  "mixtral-8x7b-32768", // older, less reliable for tool use
 ];
 const toolUseWarning = computed(() => {
   if (!settings.value.toolUseEnabled) return "";
@@ -712,6 +737,13 @@ async function loadSettings() {
     );
     moduleEnabled.value = cfg.enabled;
     settings.value = { ...settings.value, ...(cfg.settings ?? {}) };
+
+    // Legacy full prompt or empty → show the tone default (append-model migration).
+    const norm = normalizeWhitespace(settings.value.systemPrompt);
+    const isLegacy = LEGACY_DEFAULT_PROMPTS.some(
+      (p) => normalizeWhitespace(p) === norm,
+    );
+    if (!norm || isLegacy) settings.value.systemPrompt = DEFAULT_PERSONALITY;
 
     // Premium flag lives on the servers row. by-guild-ids returns just
     // the public projection we need without paginating the whole list.
@@ -865,7 +897,7 @@ watch(
 );
 
 function resetSystemPrompt() {
-  settings.value.systemPrompt = DEFAULT_SYSTEM_PROMPT;
+  settings.value.systemPrompt = DEFAULT_PERSONALITY;
 }
 
 function formatTime(ts: string) {


### PR DESCRIPTION
## Summary

Reworks the AI module so a guild's dashboard field **appends a personality/tone to an immutable bot-owned base** instead of *being* the entire system prompt, and reorganizes the AI dashboard page. Also folds in earlier AI fixes (answer completeness, output-token budget, cost logging) that this work builds on.

Started from a report that the AI gave incomplete answers (e.g. narrating "let me look that up" and stopping). Root cause was two-fold: the loop accepted narration as a final answer, and the default prompt told the model to "keep responses to 2-4 sentences." This branch removes that footgun structurally.

## What changed

**Bot**
- New pure module `bot/lib/aiPrompt.ts`: `CORE_SYSTEM_PROMPT` (immutable rules — complete answers, act-don't-narrate on tool use) + appended guild personality + tool appendix, via `buildSystemPrompt()`.
- `resolvePersonality()` maps empty **or** a whitespace-normalized legacy-default prompt → the default friendly tone, so existing guilds' stored "2-4 sentences" prompt can't leak back in.
- `bot/modules/ai.ts` composes the prompt via the helper; old inline constants removed.
- `systemPrompt` Zod field **clamps** to 2000 chars via `.transform` (not `.max` — a rejection would make `parseSettings`/`safeParse` wipe a guild's whole settings block).
- Earlier baseline fixes: rewrite prompt for complete answers + anti-narration, raise `maxOutputTokens` 300→512, replace the stale hardcoded `MODEL_PRICING` catalog with opt-in env rates (`AI_PRICE_INPUT_PER_MTOK` / `AI_PRICE_OUTPUT_PER_MTOK`), omitting `estimated_cost` when unset.

**Web** (`ai.vue`)
- "System Prompt" → **"Personality & Instructions"**: appends tone, seeded with a short friendly default, `maxlength` 2000, with a read-only "built-in behavior" preview and legacy/empty normalization on load.
- Dashboard regrouped into 6 logical cards; feature toggles (DM responses, tool use) moved out of "Limits & Rate Limiting" into a new **Behavior & Features** card.
- Cleanup: dropped the duplicated default-prompt constant and the dead `mixtral-8x7b-32768` model entry; aligned the web `maxOutputTokens` default to 512.

## Backward compatibility

Guilds that never customized their prompt (stored the old full default) are detected and shown/served the new friendly tone default — no DB migration. Guilds with genuinely custom prompts keep their text as appended tone.

## Testing

No test runner exists in this repo; verification was `tsc --noEmit` (bot) + `pnpm run build` (web) on each change, plus a throwaway `ts-node` assertion script for `resolvePersonality`/`buildSystemPrompt` and the schema clamp. All green on the final tree.

## Notes

- `CORE_BEHAVIOR_PREVIEW` in the dashboard is a hand-written paraphrase of the core prompt (read-only hint; can drift if the core changes — accepted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)