### PR TITLE
feat(bot): AI tool registry, weather tool, and intent-aware web search

### DIFF
--- a/bot/ModuleManager.ts
+++ b/bot/ModuleManager.ts
@@ -17,6 +17,7 @@ import fs from "fs";
 import path from "path";
 import { DatabaseService } from "./DatabaseService";
 import { Logger } from "./Logger";
+import type { AiTool } from "./lib/aiTools";
 
 /**
  * A slash-command definition: any command builder (SlashCommandBuilder and
@@ -75,6 +76,12 @@ export interface BotModule {
    * name so /reload cannot attach duplicate listeners.
    */
   registerEvents?: (moduleManager: ModuleManager) => void | Promise<void>;
+  /**
+   * AI tools this module exposes to the assistant. Offered to the model only
+   * when this module is enabled for the guild (and each tool's isAvailable
+   * passes). See bot/lib/aiTools.ts.
+   */
+  aiTools?: AiTool[];
 }
 
 export class ModuleManager {

--- a/bot/lib/aiPrompt.ts
+++ b/bot/lib/aiPrompt.ts
@@ -1,6 +1,7 @@
 // ── AI System Prompt Composition ───────────────────────────────────
 // The effective system prompt is layered:
 //   CORE_SYSTEM_PROMPT            (immutable rules — always applied)
+//   + current date/time context   (appended so relative dates resolve)
 //   + guild personality/tone      (appended; owned by the dashboard field)
 //   + TOOL_USE_..._APPENDIX        (appended when tool use is enabled)
 // The guild field APPENDS to the core; it never replaces it.
@@ -55,6 +56,28 @@ function normalizeWhitespace(s: string): string {
 }
 
 /**
+ * A one-line statement of the current date/time, given in UTC so it is
+ * unambiguous across guilds. Without this the model has no idea what "today"
+ * is and refuses relative-date questions ("next weekend", "tomorrow") instead
+ * of answering or reaching for web_search.
+ */
+export function formatDateContext(now: Date): string {
+  const formatted = now.toLocaleString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "UTC",
+    timeZoneName: "short",
+  });
+  return `The current date and time is ${formatted}. Use this to resolve relative \
+references such as "today", "tonight", "tomorrow", "this weekend", or "next week" \
+(times are UTC unless the user names a timezone).`;
+}
+
+/**
  * Resolve the guild's stored value into the tone text to append.
  * - empty OR a known legacy default → DEFAULT_PERSONALITY
  * - anything else → the trimmed custom text
@@ -68,12 +91,18 @@ export function resolvePersonality(raw: string | null | undefined): string {
   return (raw ?? "").trim();
 }
 
-/** Compose the effective system prompt: core + tone + (optional) tool appendix. */
+/**
+ * Compose the effective system prompt: core + current date + tone +
+ * (optional) tool appendix. `now` is injectable for deterministic tests;
+ * it defaults to the moment the message is handled.
+ */
 export function buildSystemPrompt(
   rawPersonality: string | null | undefined,
   toolUseEnabled: boolean,
+  now: Date = new Date(),
 ): string {
   let prompt = CORE_SYSTEM_PROMPT;
+  prompt += "\n\n" + formatDateContext(now);
   const tone = resolvePersonality(rawPersonality);
   if (tone) prompt += "\n\n" + tone;
   if (toolUseEnabled) prompt += "\n\n" + TOOL_USE_SYSTEM_PROMPT_APPENDIX;

--- a/bot/lib/aiTools.ts
+++ b/bot/lib/aiTools.ts
@@ -1,5 +1,5 @@
 import type { Message } from "discord.js";
-import type { ModuleManager } from "../ModuleManager";
+import type { ModuleManager, BotModule } from "../ModuleManager";
 
 /** Everything a tool's execute() needs to act on the triggering message. */
 export interface AiToolContext {
@@ -49,4 +49,51 @@ export function toAnthropicTools(tools: AiTool[]): any[] {
     description: t.description,
     input_schema: t.parameters,
   }));
+}
+
+/**
+ * Gather the AI tools available to a guild right now: from enabled modules
+ * only, keeping tools whose isAvailable() passes, first-wins on name clashes.
+ */
+export async function collectAiTools(
+  moduleManager: ModuleManager,
+  guildId: string,
+): Promise<{ tools: AiTool[]; lookup: Map<string, AiTool> }> {
+  // getRegisteredModules() is keyed by COMMAND name, so a multi-command module
+  // appears more than once — dedupe by the module's own name first.
+  const uniqueModules = new Map<string, BotModule>();
+  for (const module of moduleManager.getRegisteredModules().values()) {
+    if (!uniqueModules.has(module.name)) uniqueModules.set(module.name, module);
+  }
+
+  const tools: AiTool[] = [];
+  const lookup = new Map<string, AiTool>();
+
+  for (const [moduleName, module] of uniqueModules) {
+    if (!module.aiTools?.length) continue;
+    const enabled = await moduleManager.databaseService.isModuleEnabled(
+      guildId,
+      moduleName,
+    );
+    if (!enabled) continue;
+
+    for (const tool of module.aiTools) {
+      if (tool.isAvailable) {
+        const ok = await tool.isAvailable({ guildId, moduleManager });
+        if (!ok) continue;
+      }
+      if (lookup.has(tool.name)) {
+        await moduleManager.logger.warn(
+          `Duplicate AI tool name "${tool.name}" from module "${moduleName}" — skipping.`,
+          guildId,
+          "ai",
+        );
+        continue;
+      }
+      lookup.set(tool.name, tool);
+      tools.push(tool);
+    }
+  }
+
+  return { tools, lookup };
 }

--- a/bot/lib/aiTools.ts
+++ b/bot/lib/aiTools.ts
@@ -1,0 +1,52 @@
+import type { Message } from "discord.js";
+import type { ModuleManager } from "../ModuleManager";
+
+/** Everything a tool's execute() needs to act on the triggering message. */
+export interface AiToolContext {
+  guildId: string;
+  message: Message; // triggering message: author, member (voice channel), channel
+  moduleManager: ModuleManager;
+  args: Record<string, unknown>;
+}
+
+/** A single AI-callable action, owned by the module that exposes it. */
+export interface AiTool {
+  /** Unique across ALL modules. Used as the LLM function name. */
+  name: string;
+  /** What the model reads to decide when to call this. */
+  description: string;
+  /** Provider-neutral JSON Schema for the arguments (an "object" schema). */
+  parameters: Record<string, unknown>;
+  /**
+   * Optional runtime gate BEYOND module-enabled — e.g. a required env var.
+   * Returning false means the tool is not offered to the model this request.
+   */
+  isAvailable?: (
+    ctx: Pick<AiToolContext, "guildId" | "moduleManager">,
+  ) => boolean | Promise<boolean>;
+  /** Perform the action; return text that is fed back to the model. */
+  execute: (ctx: AiToolContext) => Promise<string>;
+}
+
+/** OpenAI / Groq / Gemini / OpenAI-Compatible function-tool format. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function toOpenAiTools(tools: AiTool[]): any[] {
+  return tools.map((t) => ({
+    type: "function",
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: t.parameters,
+    },
+  }));
+}
+
+/** Anthropic tool format (input_schema instead of parameters). */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function toAnthropicTools(tools: AiTool[]): any[] {
+  return tools.map((t) => ({
+    name: t.name,
+    description: t.description,
+    input_schema: t.parameters,
+  }));
+}

--- a/bot/lib/aiTools.ts
+++ b/bot/lib/aiTools.ts
@@ -1,5 +1,5 @@
 import type { Message } from "discord.js";
-import type { ModuleManager, BotModule } from "../ModuleManager";
+import type { ModuleManager } from "../ModuleManager";
 
 /** Everything a tool's execute() needs to act on the triggering message. */
 export interface AiToolContext {
@@ -59,17 +59,12 @@ export async function collectAiTools(
   moduleManager: ModuleManager,
   guildId: string,
 ): Promise<{ tools: AiTool[]; lookup: Map<string, AiTool> }> {
-  // getRegisteredModules() is keyed by COMMAND name, so a multi-command module
-  // appears more than once — dedupe by the module's own name first.
-  const uniqueModules = new Map<string, BotModule>();
-  for (const module of moduleManager.getRegisteredModules().values()) {
-    if (!uniqueModules.has(module.name)) uniqueModules.set(module.name, module);
-  }
-
+  // getRegisteredModules() already returns modules deduped by name.
   const tools: AiTool[] = [];
   const lookup = new Map<string, AiTool>();
 
-  for (const [moduleName, module] of uniqueModules) {
+  for (const module of moduleManager.getRegisteredModules().values()) {
+    const moduleName = module.name;
     if (!module.aiTools?.length) continue;
     const enabled = await moduleManager.databaseService.isModuleEnabled(
       guildId,

--- a/bot/lib/weather.ts
+++ b/bot/lib/weather.ts
@@ -1,0 +1,96 @@
+// Open-Meteo weather helpers (free, no API key). Times come back in the
+// location's own timezone via timezone=auto, so forecast days align to that
+// location's calendar days.
+
+export interface GeocodeResult {
+  name: string;
+  latitude: number;
+  longitude: number;
+  country_code: string;
+  timezone: string;
+  admin1?: string;
+  country?: string;
+}
+
+export interface ForecastResponse {
+  timezone: string;
+  current: {
+    time: string;
+    temperature_2m: number;
+    apparent_temperature: number;
+    relative_humidity_2m: number;
+    weather_code: number;
+    wind_speed_10m: number;
+  };
+  daily: {
+    time: string[];
+    weather_code: number[];
+    temperature_2m_max: number[];
+    temperature_2m_min: number[];
+    precipitation_probability_max: number[];
+  };
+}
+
+// WMO weather interpretation codes → plain text.
+export const WMO_DESCRIPTIONS: Record<number, string> = {
+  0: "Clear sky", 1: "Mainly clear", 2: "Partly cloudy", 3: "Overcast",
+  45: "Fog", 48: "Depositing rime fog",
+  51: "Light drizzle", 53: "Moderate drizzle", 55: "Dense drizzle",
+  56: "Light freezing drizzle", 57: "Dense freezing drizzle",
+  61: "Light rain", 63: "Moderate rain", 65: "Heavy rain",
+  66: "Light freezing rain", 67: "Heavy freezing rain",
+  71: "Light snow", 73: "Moderate snow", 75: "Heavy snow", 77: "Snow grains",
+  80: "Light rain showers", 81: "Moderate rain showers", 82: "Violent rain showers",
+  85: "Light snow showers", 86: "Heavy snow showers",
+  95: "Thunderstorm", 96: "Thunderstorm with light hail", 99: "Thunderstorm with heavy hail",
+};
+
+export function describeWeatherCode(code: number): string {
+  return WMO_DESCRIPTIONS[code] ?? `code ${code}`;
+}
+
+// Countries that use Fahrenheit / imperial for everyday weather.
+const IMPERIAL_COUNTRIES = new Set(["US", "BS", "BZ", "KY", "LR", "PW", "FM", "MH"]);
+
+export interface UnitChoice {
+  imperial: boolean;
+  temperatureUnit: "fahrenheit" | "celsius";
+  windSpeedUnit: "mph" | "kmh";
+}
+
+export function selectUnits(countryCode: string): UnitChoice {
+  const imperial = IMPERIAL_COUNTRIES.has((countryCode ?? "").toUpperCase());
+  return {
+    imperial,
+    temperatureUnit: imperial ? "fahrenheit" : "celsius",
+    windSpeedUnit: imperial ? "mph" : "kmh",
+  };
+}
+
+export function cToF(c: number): number { return (c * 9) / 5 + 32; }
+export function fToC(f: number): number { return ((f - 32) * 5) / 9; }
+
+// Given a temperature already in the primary unit, render BOTH units, e.g. "74°F / 23°C".
+export function formatTemp(value: number, imperial: boolean): string {
+  const f = imperial ? value : cToF(value);
+  const c = imperial ? fToC(value) : value;
+  return `${Math.round(f)}°F / ${Math.round(c)}°C`;
+}
+
+export function buildGeocodeUrl(location: string): string {
+  return `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(location)}&count=1&language=en&format=json`;
+}
+
+export function buildForecastUrl(lat: number, lon: number, units: UnitChoice): string {
+  const params = new URLSearchParams({
+    latitude: String(lat),
+    longitude: String(lon),
+    current: "temperature_2m,apparent_temperature,relative_humidity_2m,weather_code,wind_speed_10m",
+    daily: "weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max",
+    timezone: "auto",
+    forecast_days: "7",
+    temperature_unit: units.temperatureUnit,
+    wind_speed_unit: units.windSpeedUnit,
+  });
+  return `https://api.open-meteo.com/v1/forecast?${params.toString()}`;
+}

--- a/bot/lib/weather.ts
+++ b/bot/lib/weather.ts
@@ -113,11 +113,12 @@ export function formatWeatherReport(
   );
   lines.push("Forecast:");
   for (let i = 0; i < fc.daily.time.length; i++) {
+    const precip = fc.daily.precipitation_probability_max[i];
     lines.push(
       `${fc.daily.time[i]}: ${describeWeatherCode(fc.daily.weather_code[i])}, ` +
         `high ${formatTemp(fc.daily.temperature_2m_max[i], units.imperial)}, ` +
         `low ${formatTemp(fc.daily.temperature_2m_min[i], units.imperial)}, ` +
-        `precip ${fc.daily.precipitation_probability_max[i]}%.`,
+        `precip ${precip == null ? "n/a" : `${precip}%`}.`,
     );
   }
   return lines.join("\n");
@@ -164,5 +165,9 @@ export async function getWeather(
     return "❌ Couldn't reach the weather service. Try again in a moment.";
   }
 
-  return formatWeatherReport(geo, fc, units);
+  if (!fc?.current || !fc?.daily?.time) {
+    return "❌ The weather service returned unexpected data. Try again in a moment.";
+  }
+
+  return formatWeatherReport(geo, fc, units).slice(0, 2000);
 }

--- a/bot/lib/weather.ts
+++ b/bot/lib/weather.ts
@@ -94,3 +94,75 @@ export function buildForecastUrl(lat: number, lon: number, units: UnitChoice): s
   });
   return `https://api.open-meteo.com/v1/forecast?${params.toString()}`;
 }
+
+export function formatWeatherReport(
+  geo: GeocodeResult,
+  fc: ForecastResponse,
+  units: UnitChoice,
+): string {
+  const place = [geo.name, geo.admin1, geo.country].filter(Boolean).join(", ");
+  const windUnit = units.imperial ? "mph" : "km/h";
+  const lines: string[] = [];
+  lines.push(`Weather for ${place} (local time ${fc.current.time}, ${fc.timezone}):`);
+  lines.push(
+    `Now: ${formatTemp(fc.current.temperature_2m, units.imperial)}, ` +
+      `feels like ${formatTemp(fc.current.apparent_temperature, units.imperial)}, ` +
+      `${describeWeatherCode(fc.current.weather_code)}, ` +
+      `wind ${Math.round(fc.current.wind_speed_10m)} ${windUnit}, ` +
+      `humidity ${fc.current.relative_humidity_2m}%.`,
+  );
+  lines.push("Forecast:");
+  for (let i = 0; i < fc.daily.time.length; i++) {
+    lines.push(
+      `${fc.daily.time[i]}: ${describeWeatherCode(fc.daily.weather_code[i])}, ` +
+        `high ${formatTemp(fc.daily.temperature_2m_max[i], units.imperial)}, ` +
+        `low ${formatTemp(fc.daily.temperature_2m_min[i], units.imperial)}, ` +
+        `precip ${fc.daily.precipitation_probability_max[i]}%.`,
+    );
+  }
+  return lines.join("\n");
+}
+
+// Minimal shape we need from a fetch response — keeps getWeather testable.
+type FetchLike = (url: string) => Promise<{
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+}>;
+
+const defaultFetch: FetchLike = (url) =>
+  fetch(url, { signal: AbortSignal.timeout(8000) }) as unknown as ReturnType<FetchLike>;
+
+/** Geocode a location, fetch its current+7-day forecast, and format it for the model. */
+export async function getWeather(
+  location: string,
+  fetchImpl: FetchLike = defaultFetch,
+): Promise<string> {
+  if (!location.trim()) return "❌ I need a location to check the weather.";
+
+  let geoJson: { results?: GeocodeResult[] };
+  try {
+    const res = await fetchImpl(buildGeocodeUrl(location));
+    if (!res.ok) return `❌ Weather lookup failed (geocoding HTTP ${res.status}).`;
+    geoJson = (await res.json()) as { results?: GeocodeResult[] };
+  } catch {
+    return "❌ Couldn't reach the geocoding service. Try again in a moment.";
+  }
+  const geo = geoJson?.results?.[0];
+  if (!geo) {
+    return `❌ I couldn't find a location called "${location}". Try adding a state or country.`;
+  }
+
+  const units = selectUnits(geo.country_code);
+
+  let fc: ForecastResponse;
+  try {
+    const res = await fetchImpl(buildForecastUrl(geo.latitude, geo.longitude, units));
+    if (!res.ok) return `❌ Weather lookup failed (forecast HTTP ${res.status}).`;
+    fc = (await res.json()) as ForecastResponse;
+  } catch {
+    return "❌ Couldn't reach the weather service. Try again in a moment.";
+  }
+
+  return formatWeatherReport(geo, fc, units);
+}

--- a/bot/modules/ai.ts
+++ b/bot/modules/ai.ts
@@ -390,11 +390,33 @@ async function callLLM(
 
 // ── Web Search ─────────────────────────────────────────────────────
 
-async function performWebSearch(query: string): Promise<string> {
+// Compose the SearXNG query URL. `category` picks the vertical (general|news);
+// `timeRange` (day|week|month) restricts recency when provided.
+export function buildSearchUrl(
+  baseUrl: string,
+  query: string,
+  category: string,
+  timeRange?: string,
+): string {
+  const params = new URLSearchParams({
+    q: query,
+    format: "json",
+    categories: category,
+    language: "en",
+  });
+  if (timeRange) params.set("time_range", timeRange);
+  return `${baseUrl}/search?${params.toString()}`;
+}
+
+async function performWebSearch(
+  query: string,
+  category: string = "general",
+  timeRange?: string,
+): Promise<string> {
   const baseUrl = process.env.SEARXNG_URL?.replace(/\/$/, "");
   if (!baseUrl) throw new Error("SEARXNG_URL not configured");
 
-  const searchUrl = `${baseUrl}/search?q=${encodeURIComponent(query)}&format=json&categories=general&language=en`;
+  const searchUrl = buildSearchUrl(baseUrl, query, category, timeRange);
   const parsed = new URL(searchUrl);
   const requester = parsed.protocol === "https:" ? https : http;
 
@@ -498,11 +520,25 @@ const aiCoreTools: AiTool[] = [
   {
     name: "web_search",
     description:
-      "Search the web for current, real-time information. Use this when the user asks about recent events, news, current prices, weather, live scores, or anything that requires up-to-date information you might not have.",
+      "Search the web for current, real-time information (recent events, news, prices, live scores, facts). For headlines or 'latest' questions, set category='news' and recency='day'. Use category='general' for stock prices, sports scores, and factual lookups. ALWAYS include the location or country in the query when the question is location-specific. (For weather, use get_weather instead.)",
     parameters: {
       type: "object",
       properties: {
-        query: { type: "string", description: "The search query to look up on the web." },
+        query: {
+          type: "string",
+          description:
+            "The search query. Include location/country when relevant, e.g. 'election results South Carolina'.",
+        },
+        category: {
+          type: "string",
+          enum: ["general", "news"],
+          description: "'news' for headlines/current events; 'general' (default) for everything else.",
+        },
+        recency: {
+          type: "string",
+          enum: ["day", "week", "month"],
+          description: "Restrict to recent results. Use 'day' for today's news. Omit for timeless queries.",
+        },
       },
       required: ["query"],
     },
@@ -513,7 +549,11 @@ const aiCoreTools: AiTool[] = [
       if (!process.env.SEARXNG_URL) {
         return "❌ Web search isn't configured. The bot owner needs to set `SEARXNG_URL` to a running SearXNG instance.";
       }
-      const results = await performWebSearch(query);
+      const category = args.category === "news" ? "news" : "general";
+      const recency = args.recency;
+      const timeRange =
+        recency === "day" || recency === "week" || recency === "month" ? recency : undefined;
+      const results = await performWebSearch(query, category, timeRange);
       return results.slice(0, 3200);
     },
   },

--- a/bot/modules/ai.ts
+++ b/bot/modules/ai.ts
@@ -12,6 +12,7 @@ import { AISettingsSchema } from "../lib/schemas";
 import { parseSettings } from "../lib/validateSettings";
 import { buildSystemPrompt } from "../lib/aiPrompt";
 import { AiTool, collectAiTools, toOpenAiTools, toAnthropicTools } from "../lib/aiTools";
+import { getWeather } from "../lib/weather";
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -515,6 +516,23 @@ const aiCoreTools: AiTool[] = [
       const results = await performWebSearch(query);
       return results.slice(0, 3200);
     },
+  },
+  {
+    name: "get_weather",
+    description:
+      "Get current weather and a 7-day forecast for a location. Use this for ANY weather question — current conditions or the forecast for a specific day (today, tomorrow, this weekend). Prefer this over web_search for weather.",
+    parameters: {
+      type: "object",
+      properties: {
+        location: {
+          type: "string",
+          description:
+            "City, with state/country if ambiguous, e.g. 'North Augusta SC' or 'Tokyo'.",
+        },
+      },
+      required: ["location"],
+    },
+    execute: async ({ args }) => getWeather((args.location as string) || ""),
   },
 ];
 

--- a/bot/modules/ai.ts
+++ b/bot/modules/ai.ts
@@ -12,17 +12,7 @@ import { BotModule, ModuleManager } from "../ModuleManager";
 import { AISettingsSchema } from "../lib/schemas";
 import { parseSettings } from "../lib/validateSettings";
 import { buildSystemPrompt } from "../lib/aiPrompt";
-import {
-  musicPlay,
-  musicSkip,
-  musicStop,
-  musicPause,
-  musicResume,
-  musicSetVolume,
-  musicGetQueue,
-  musicGetNowPlaying,
-  musicShuffle,
-} from "./music";
+import { AiTool, collectAiTools, toOpenAiTools, toAnthropicTools } from "../lib/aiTools";
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -235,133 +225,6 @@ function resolveBaseUrl(provider: AIProvider, customUrl?: string): string {
   }
 }
 
-// ── Tool Schema Definitions ────────────────────────────────────────
-// OpenAI function-calling format (also used by Groq, Gemini, OpenAI Compatible).
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const OPENAI_TOOLS: any[] = [
-  {
-    type: "function",
-    function: {
-      name: "play_music",
-      description:
-        "Play a song or add it to the music queue. Use this when the user wants to play, queue, or listen to music.",
-      parameters: {
-        type: "object",
-        properties: {
-          query: {
-            type: "string",
-            description:
-              "The song name, artist name, or a YouTube/Spotify URL to play.",
-          },
-        },
-        required: ["query"],
-      },
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "skip_track",
-      description: "Skip the currently playing track and move to the next one.",
-      parameters: { type: "object", properties: {} },
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "stop_music",
-      description: "Stop all music playback and clear the entire queue.",
-      parameters: { type: "object", properties: {} },
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "pause_music",
-      description: "Pause the currently playing track.",
-      parameters: { type: "object", properties: {} },
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "resume_music",
-      description: "Resume a paused track.",
-      parameters: { type: "object", properties: {} },
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "set_volume",
-      description:
-        "Set the playback volume to a specific percentage between 1 and 100.",
-      parameters: {
-        type: "object",
-        properties: {
-          level: {
-            type: "number",
-            description: "Volume level from 1 to 100.",
-          },
-        },
-        required: ["level"],
-      },
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "get_queue",
-      description:
-        "Show what is currently in the music queue, including what is playing and what is up next.",
-      parameters: { type: "object", properties: {} },
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "get_nowplaying",
-      description:
-        "Show information about the track that is currently playing.",
-      parameters: { type: "object", properties: {} },
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "shuffle_queue",
-      description: "Shuffle the tracks in the music queue into a random order.",
-      parameters: { type: "object", properties: {} },
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "web_search",
-      description:
-        "Search the web for current, real-time information. Use this when the user asks about recent events, news, current prices, weather, live scores, or anything that requires up-to-date information you might not have.",
-      parameters: {
-        type: "object",
-        properties: {
-          query: {
-            type: "string",
-            description: "The search query to look up on the web.",
-          },
-        },
-        required: ["query"],
-      },
-    },
-  },
-];
-
-// Anthropic tool format (input_schema instead of parameters)
-const ANTHROPIC_TOOLS: Anthropic.Tool[] = OPENAI_TOOLS.map((t) => ({
-  name: (t.function as any).name as string,
-  description: ((t.function as any).description ?? "") as string,
-  input_schema: (t.function as any).parameters as Anthropic.Tool.InputSchema,
-}));
-
 // ── Unified LLM Caller ─────────────────────────────────────────────
 
 async function callLLM(
@@ -371,7 +234,7 @@ async function callLLM(
   messages: ChatMessage[],
   maxOutputTokens: number,
   baseUrl?: string,
-  toolsEnabled?: boolean,
+  tools: AiTool[] = [],
 ): Promise<LLMResponse> {
   // Separate out system prompt from conversation messages
   const systemMsg = messages.find((m) => m.role === "system");
@@ -415,13 +278,13 @@ async function callLLM(
           content: m.content,
         };
       }),
-      ...(toolsEnabled ? { tools: ANTHROPIC_TOOLS } : {}),
+      ...(tools.length ? { tools: toAnthropicTools(tools) } : {}),
     };
 
     const response = await anthropic.messages.create(createParams);
 
     // Check for tool use
-    if (toolsEnabled && response.stop_reason === "tool_use") {
+    if (tools.length && response.stop_reason === "tool_use") {
       const toolBlocks = response.content.filter((b) => b.type === "tool_use") as Anthropic.ToolUseBlock[];
       const textBlock = response.content.find((b) => b.type === "text") as Anthropic.TextBlock | undefined;
       
@@ -485,7 +348,7 @@ async function callLLM(
         };
       }),
     ],
-    ...(toolsEnabled ? { tools: OPENAI_TOOLS, tool_choice: "auto" } : {}),
+    ...(tools.length ? { tools: toOpenAiTools(tools), tool_choice: "auto" } : {}),
   });
 
   const choice = response.choices[0];
@@ -493,7 +356,7 @@ async function callLLM(
 
   // Check for tool call response
   if (
-    toolsEnabled &&
+    tools.length &&
     choice?.finish_reason === "tool_calls" &&
     choice.message?.tool_calls?.length
   ) {
@@ -580,109 +443,6 @@ async function performWebSearch(query: string): Promise<string> {
   });
 }
 
-// ── Tool Router ────────────────────────────────────────────────────
-// Executes the tool call returned by the LLM and returns the result.
-
-async function executeToolCall(
-  toolCall: ToolCall,
-  message: Message,
-  guildId: string,
-  moduleManager: ModuleManager,
-): Promise<string> {
-  const { name, args } = toolCall;
-
-  // ── Web search (no module dependency) ──────────────────────────
-  if (name === "web_search") {
-    const query = (args.query as string) || "";
-    if (!query) return "❌ I need a search query to look something up.";
-    if (!process.env.SEARXNG_URL) {
-      return "❌ Web search isn't configured. The bot owner needs to set `SEARXNG_URL` to a running SearXNG instance.";
-    }
-    const results = await performWebSearch(query);
-    return results.slice(0, 3200);
-  }
-
-  // All music tools require the music module to be enabled
-  const isMusicEnabled = await moduleManager.databaseService.isModuleEnabled(
-    guildId,
-    "music",
-  );
-  if (!isMusicEnabled) {
-    return "❌ The music module is not enabled on this server. Ask an admin to enable it in the dashboard.";
-  }
-
-  switch (name) {
-    case "play_music": {
-      const query = (args.query as string) || "";
-      if (!query) return "❌ I need a song name or URL to play something.";
-
-      // Resolve the user's voice channel from the message member
-      const member = message.member as GuildMember | null;
-      const voiceChannel = member?.voice?.channel;
-      if (!voiceChannel) {
-        return "❌ You need to be in a voice channel for me to play music!";
-      }
-
-      const result = await musicPlay(
-        guildId,
-        voiceChannel,
-        query,
-        message.author,
-        moduleManager,
-        message.channel as any,
-      );
-      return result.message;
-    }
-
-    case "skip_track": {
-      const result = await musicSkip(guildId);
-      return result.message;
-    }
-
-    case "stop_music": {
-      const result = await musicStop(guildId, moduleManager);
-      return result.message;
-    }
-
-    case "pause_music": {
-      const result = await musicPause(guildId);
-      return result.message;
-    }
-
-    case "resume_music": {
-      const result = await musicResume(guildId);
-      return result.message;
-    }
-
-    case "set_volume": {
-      const level =
-        typeof args.level === "number" ? args.level : Number(args.level);
-      if (isNaN(level))
-        return "❌ Please specify a valid volume level (1–100).";
-      const result = await musicSetVolume(guildId, level, moduleManager);
-      return result.message;
-    }
-
-    case "get_queue": {
-      const result = await musicGetQueue(guildId);
-      return result.message;
-    }
-
-    case "get_nowplaying": {
-      const result = await musicGetNowPlaying(guildId);
-      return result.message;
-    }
-
-    case "shuffle_queue": {
-      const result = await musicShuffle(guildId);
-      return result.message;
-    }
-
-    default:
-      return `❓ I tried to use an unknown tool: \`${name}\`. That's a bug — please report it!`;
-  }
-}
-
 // ── Rate Limiting ──────────────────────────────────────────────────
 // In-memory cooldown map: "guildId:userId" → last call timestamp (ms)
 
@@ -733,10 +493,37 @@ const DEFAULT_SETTINGS: Required<AIModuleSettings> = {
   contextTTLMinutes: 15,
 };
 
+// ── Core AI tools (owned by the ai module itself) ──────────────────
+const aiCoreTools: AiTool[] = [
+  {
+    name: "web_search",
+    description:
+      "Search the web for current, real-time information. Use this when the user asks about recent events, news, current prices, weather, live scores, or anything that requires up-to-date information you might not have.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "The search query to look up on the web." },
+      },
+      required: ["query"],
+    },
+    isAvailable: () => !!process.env.SEARXNG_URL,
+    execute: async ({ args }) => {
+      const query = (args.query as string) || "";
+      if (!query) return "❌ I need a search query to look something up.";
+      if (!process.env.SEARXNG_URL) {
+        return "❌ Web search isn't configured. The bot owner needs to set `SEARXNG_URL` to a running SearXNG instance.";
+      }
+      const results = await performWebSearch(query);
+      return results.slice(0, 3200);
+    },
+  },
+];
+
 // ── Module Definition ──────────────────────────────────────────────
 
 const aiModule: BotModule = {
   name: "ai",
+  aiTools: aiCoreTools,
   registerEvents: registerAIEvents,
   description: "AI conversational assistant — @mention the bot to chat",
   data: new SlashCommandBuilder()
@@ -998,6 +785,11 @@ export function registerAIEvents(moduleManager: ModuleManager) {
       llmMessages.push({ role: "user", content: trimmedMessage });
       const newMessagesStartIndex = llmMessages.length - 1;
 
+      // Gather the tools this guild may use right now (enabled modules only).
+      const { tools: aiTools, lookup: aiToolLookup } = settings.toolUseEnabled
+        ? await collectAiTools(moduleManager, guildId)
+        : { tools: [] as AiTool[], lookup: new Map<string, AiTool>() };
+
       // ─ Agent Loop ─────────────────────────────────────────────
       let reply = "";
       let action: "chat" | "tool_use" = "chat";
@@ -1022,7 +814,7 @@ export function registerAIEvents(moduleManager: ModuleManager) {
           llmMessages,
           settings.maxOutputTokens,
           settings.aiBaseUrl || undefined,
-          settings.toolUseEnabled,
+          aiTools,
         );
 
         totalInputTokens += result.input_tokens;
@@ -1050,7 +842,10 @@ export function registerAIEvents(moduleManager: ModuleManager) {
               if ("sendTyping" in message.channel) {
                 await message.channel.sendTyping().catch(() => {});
               }
-              const execResult = await executeToolCall(tc, message, guildId, moduleManager);
+              const tool = aiToolLookup.get(tc.name);
+              const execResult = tool
+                ? await tool.execute({ guildId, message, moduleManager, args: tc.args })
+                : `❓ I tried to use an unknown tool: \`${tc.name}\`. That's a bug — please report it!`;
               return {
                 role: "tool" as const,
                 content: execResult,

--- a/bot/modules/ai.ts
+++ b/bot/modules/ai.ts
@@ -2,7 +2,6 @@ import {
   ChatInputCommandInteraction,
   SlashCommandBuilder,
   Message,
-  GuildMember,
 } from "discord.js";
 import http from "http";
 import https from "https";
@@ -735,11 +734,16 @@ export function registerAIEvents(moduleManager: ModuleManager) {
         await message.channel.sendTyping().catch(() => {});
       }
 
+      // Gather the tools this guild may use right now (enabled modules only).
+      const { tools: aiTools, lookup: aiToolLookup } = settings.toolUseEnabled
+        ? await collectAiTools(moduleManager, guildId)
+        : { tools: [] as AiTool[], lookup: new Map<string, AiTool>() };
+
       // ─ Build effective system prompt ─────────────────────────────
       // Core rules (always) + guild personality (appended) + tool appendix.
       const effectiveSystemPrompt = buildSystemPrompt(
         settings.systemPrompt,
-        settings.toolUseEnabled,
+        aiTools.length > 0,
       );
 
       // ─ Build messages array with conversation context ────────────
@@ -784,11 +788,6 @@ export function registerAIEvents(moduleManager: ModuleManager) {
       // Add the new user message
       llmMessages.push({ role: "user", content: trimmedMessage });
       const newMessagesStartIndex = llmMessages.length - 1;
-
-      // Gather the tools this guild may use right now (enabled modules only).
-      const { tools: aiTools, lookup: aiToolLookup } = settings.toolUseEnabled
-        ? await collectAiTools(moduleManager, guildId)
-        : { tools: [] as AiTool[], lookup: new Map<string, AiTool>() };
 
       // ─ Agent Loop ─────────────────────────────────────────────
       let reply = "";

--- a/bot/modules/music.ts
+++ b/bot/modules/music.ts
@@ -22,6 +22,7 @@ import {
 import { YoutubeiExtractor } from "discord-player-youtubei";
 import type { ModuleManager } from "../ModuleManager";
 import type { BotModule } from "../ModuleManager";
+import type { AiTool } from "../lib/aiTools";
 import { activeSessions as recordingActiveSessions } from "./recording";
 import { MusicSettingsSchema, type MusicSettings } from "../lib/schemas";
 import { parseSettings } from "../lib/validateSettings";
@@ -1327,6 +1328,105 @@ function loopModeToString(mode: QueueRepeatMode): string {
   }
 }
 
+// ─── AI Tool Actions ─────────────────────────────────────────────────────
+
+export const musicAiTools: AiTool[] = [
+  {
+    name: "play_music",
+    description:
+      "Play a song or add it to the music queue. Use this when the user wants to play, queue, or listen to music.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "The song name, artist name, or a YouTube/Spotify URL to play.",
+        },
+      },
+      required: ["query"],
+    },
+    execute: async ({ guildId, message, moduleManager, args }) => {
+      const query = (args.query as string) || "";
+      if (!query) return "❌ I need a song name or URL to play something.";
+      const member = message.member as GuildMember | null;
+      const voiceChannel = member?.voice?.channel;
+      if (!voiceChannel) {
+        return "❌ You need to be in a voice channel for me to play music!";
+      }
+      const result = await musicPlay(
+        guildId,
+        voiceChannel,
+        query,
+        message.author,
+        moduleManager,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        message.channel as any,
+      );
+      return result.message;
+    },
+  },
+  {
+    name: "skip_track",
+    description: "Skip the currently playing track and move to the next one.",
+    parameters: { type: "object", properties: {} },
+    execute: async ({ guildId }) => (await musicSkip(guildId)).message,
+  },
+  {
+    name: "stop_music",
+    description: "Stop all music playback and clear the entire queue.",
+    parameters: { type: "object", properties: {} },
+    execute: async ({ guildId, moduleManager }) =>
+      (await musicStop(guildId, moduleManager)).message,
+  },
+  {
+    name: "pause_music",
+    description: "Pause the currently playing track.",
+    parameters: { type: "object", properties: {} },
+    execute: async ({ guildId }) => (await musicPause(guildId)).message,
+  },
+  {
+    name: "resume_music",
+    description: "Resume a paused track.",
+    parameters: { type: "object", properties: {} },
+    execute: async ({ guildId }) => (await musicResume(guildId)).message,
+  },
+  {
+    name: "set_volume",
+    description: "Set the playback volume to a specific percentage between 1 and 100.",
+    parameters: {
+      type: "object",
+      properties: {
+        level: { type: "number", description: "Volume level from 1 to 100." },
+      },
+      required: ["level"],
+    },
+    execute: async ({ guildId, moduleManager, args }) => {
+      const level = typeof args.level === "number" ? args.level : Number(args.level);
+      if (isNaN(level)) return "❌ Please specify a valid volume level (1–100).";
+      return (await musicSetVolume(guildId, level, moduleManager)).message;
+    },
+  },
+  {
+    name: "get_queue",
+    description:
+      "Show what is currently in the music queue, including what is playing and what is up next.",
+    parameters: { type: "object", properties: {} },
+    execute: async ({ guildId }) => (await musicGetQueue(guildId)).message,
+  },
+  {
+    name: "get_nowplaying",
+    description: "Show information about the track that is currently playing.",
+    parameters: { type: "object", properties: {} },
+    execute: async ({ guildId }) => (await musicGetNowPlaying(guildId)).message,
+  },
+  {
+    name: "shuffle_queue",
+    description: "Shuffle the tracks in the music queue into a random order.",
+    parameters: { type: "object", properties: {} },
+    execute: async ({ guildId }) => (await musicShuffle(guildId)).message,
+  },
+];
+
 // ─── Module Export ────────────────────────────────────────────────────────
 
 const musicModule: BotModule = {
@@ -1334,6 +1434,7 @@ const musicModule: BotModule = {
   description:
     "Play music from YouTube, Spotify, and more with queue management.",
   deferReply: false, // We handle our own defer for public replies
+  aiTools: musicAiTools,
 
   // Register all music commands as individual top-level commands
   commands: [


### PR DESCRIPTION
## Summary

Builds the foundation for AI-driven module actions and lands the first external-info tools. Three logically-stacked pieces:

1. **AI tool registry** — modules now declare their own AI tools via `BotModule.aiTools` (a provider-neutral `AiTool` interface in `bot/lib/aiTools.ts`). `ai.ts` collects tools per-guild from *enabled* modules and adapts them to OpenAI/Anthropic formats, replacing ~200 lines of hardcoded schema arrays + a dispatch switch. Music tools moved to the music module; `web_search` to the ai module. Tools are now only offered to the model when their owning module is enabled.

2. **Current-date context** — the AI system prompt now includes today's UTC date/time (`formatDateContext`), so the assistant can resolve relative-date questions ("tomorrow", "next weekend") instead of declining them.

3. **Better external-info tools (closes #34)**
   - **`get_weather`** — dedicated Open-Meteo tool (free, no API key): geocodes the location, fetches current conditions + a 7-day forecast in the location's own timezone, and renders both °F/°C with WMO codes mapped to text. Pairs with the date fix so forecast-for-a-future-day questions work.
   - **Intent-aware `web_search`** — adds `category` (general/news) and `recency` (day/week/month) params mapped to SearXNG's `categories`/`time_range`, plus location-aware prompting.

## Testing

This repo has no test runner (per `CLAUDE.md`). Each change was verified with standalone `ts-node` checks (pure helpers, mocked-fetch orchestration, tool wiring, URL/param routing) and `tsc --noEmit`, which is clean on the final tree. Reviewed task-by-task and as a whole via multi-agent review; all findings addressed.

## Notes

- Open-Meteo needs no key; `web_search` remains gated on `SEARXNG_URL`.
- Deferred follow-ups (own specs): a `create_poll` AI tool and a reminders module; dedicated stocks/sports/news APIs if the smarter `web_search` proves insufficient.

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)
