### PR TITLE
fix(triggers): allow editing trigger channel and configuration

### DIFF
--- a/bot/modules/triggers.ts
+++ b/bot/modules/triggers.ts
@@ -101,6 +101,61 @@ const triggersModule: BotModule = {
         ),
     )
     .addSubcommand((sub) =>
+      sub
+        .setName("edit")
+        .setDescription("Edit an existing trigger configuration")
+        .addStringOption((opt) =>
+          opt
+            .setName("name")
+            .setDescription("Name of the trigger to edit")
+            .setRequired(true)
+            .setAutocomplete(true),
+        )
+        .addChannelOption((opt) =>
+          opt
+            .setName("channel")
+            .setDescription("New channel to post trigger messages to")
+            .addChannelTypes(ChannelType.GuildText)
+            .setRequired(false),
+        )
+        .addStringOption((opt) =>
+          opt
+            .setName("provider")
+            .setDescription("New provider type")
+            .setRequired(false)
+            .addChoices(
+              { name: "Generic Webhook", value: "webhook" },
+              { name: "GitHub", value: "github" },
+              { name: "Twitch", value: "twitch" },
+            ),
+        )
+        .addStringOption((opt) =>
+          opt
+            .setName("new_name")
+            .setDescription("New name for this trigger")
+            .setRequired(false)
+            .setMaxLength(128),
+        )
+        .addBooleanOption((opt) =>
+          opt
+            .setName("enabled")
+            .setDescription("Enable or disable this trigger")
+            .setRequired(false),
+        )
+        .addStringOption((opt) =>
+          opt
+            .setName("template")
+            .setDescription("New custom embed template (JSON)")
+            .setRequired(false),
+        )
+        .addStringOption((opt) =>
+          opt
+            .setName("filter")
+            .setDescription("New filter conditions (JSON)")
+            .setRequired(false),
+        ),
+    )
+    .addSubcommand((sub) =>
       sub.setName("list").setDescription("List all triggers for this server"),
     )
     .addSubcommand((sub) =>
@@ -258,6 +313,120 @@ const triggersModule: BotModule = {
           .setFooter({
             text: "Paste this URL into your service's webhook settings",
           });
+
+        await interaction.editReply({ embeds: [embed] });
+        break;
+      }
+
+      // ── Edit ────────────────────────────────────────────────────────
+      case "edit": {
+        const name = interaction.options.getString("name", true);
+        const channel = interaction.options.getChannel("channel");
+        const provider = interaction.options.getString("provider");
+        const newName = interaction.options.getString("new_name")?.trim();
+        const enabled = interaction.options.getBoolean("enabled");
+        const templateStr = interaction.options.getString("template");
+        const filterStr = interaction.options.getString("filter");
+
+        const triggers = await db.listTriggers(guildId);
+        const trigger = triggers.find(
+          (t: any) => t.name.toLowerCase() === name.toLowerCase(),
+        );
+
+        if (!trigger) {
+          await interaction.editReply(`❌ No trigger named **${name}** found.`);
+          return;
+        }
+
+        const patch: Record<string, any> = {};
+
+        if (channel) {
+          patch.channel_id = channel.id;
+        }
+
+        if (provider) {
+          patch.provider = provider;
+        }
+
+        if (enabled !== null && enabled !== undefined) {
+          patch.enabled = enabled;
+        }
+
+        if (newName) {
+          if (
+            newName.toLowerCase() !== trigger.name.toLowerCase() &&
+            triggers.some(
+              (t: any) => t.name.toLowerCase() === newName.toLowerCase(),
+            )
+          ) {
+            await interaction.editReply(
+              `❌ A trigger named **${newName}** already exists. Choose a different name.`,
+            );
+            return;
+          }
+          patch.name = newName;
+        }
+
+        if (templateStr !== null && templateStr !== undefined) {
+          try {
+            JSON.parse(templateStr);
+            patch.embed_template = templateStr;
+          } catch {
+            await interaction.editReply(
+              "❌ Invalid JSON format for embed template.",
+            );
+            return;
+          }
+        }
+
+        if (filterStr !== null && filterStr !== undefined) {
+          try {
+            JSON.parse(filterStr);
+            patch.filters = filterStr;
+          } catch {
+            await interaction.editReply(
+              "❌ Invalid JSON format for filter conditions.",
+            );
+            return;
+          }
+        }
+
+        if (Object.keys(patch).length === 0) {
+          await interaction.editReply(
+            "⚠️ No changes provided. Please specify at least one option to update.",
+          );
+          return;
+        }
+
+        await db.updateTrigger(trigger.$id, patch);
+
+        const updatedName = patch.name || trigger.name;
+        const finalChannelId = patch.channel_id || trigger.channel_id;
+        const finalProvider = patch.provider || trigger.provider;
+        const finalEnabled =
+          patch.enabled !== undefined ? patch.enabled : trigger.enabled;
+
+        const embed = new EmbedBuilder()
+          .setColor(0x57f287)
+          .setTitle("✅ Trigger Updated")
+          .setDescription(`Successfully updated trigger **${updatedName}**.`)
+          .addFields(
+            {
+              name: "Channel",
+              value: `<#${finalChannelId}>`,
+              inline: true,
+            },
+            {
+              name: "Provider",
+              value: finalProvider,
+              inline: true,
+            },
+            {
+              name: "Status",
+              value: finalEnabled ? "Active ✅" : "Disabled ❌",
+              inline: true,
+            },
+          );
 
         await interaction.editReply({ embeds: [embed] });
         break;

--- a/bot/slash-commands.json
+++ b/bot/slash-commands.json
@@ -1197,6 +1197,73 @@
       },
       {
         "type": 1,
+        "name": "edit",
+        "description": "Edit an existing trigger configuration",
+        "options": [
+          {
+            "autocomplete": true,
+            "type": 3,
+            "name": "name",
+            "description": "Name of the trigger to edit",
+            "required": true
+          },
+          {
+            "channel_types": [
+              0
+            ],
+            "name": "channel",
+            "description": "New channel to post trigger messages to",
+            "required": false,
+            "type": 7
+          },
+          {
+            "type": 3,
+            "choices": [
+              {
+                "name": "Generic Webhook",
+                "value": "webhook"
+              },
+              {
+                "name": "GitHub",
+                "value": "github"
+              },
+              {
+                "name": "Twitch",
+                "value": "twitch"
+              }
+            ],
+            "name": "provider",
+            "description": "New provider type",
+            "required": false
+          },
+          {
+            "type": 3,
+            "name": "new_name",
+            "description": "New name for this trigger",
+            "required": false
+          },
+          {
+            "type": 5,
+            "name": "enabled",
+            "description": "Enable or disable this trigger",
+            "required": false
+          },
+          {
+            "type": 3,
+            "name": "template",
+            "description": "New custom embed template (JSON)",
+            "required": false
+          },
+          {
+            "type": 3,
+            "name": "filter",
+            "description": "New filter conditions (JSON)",
+            "required": false
+          }
+        ]
+      },
+      {
+        "type": 1,
         "name": "list",
         "description": "List all triggers for this server",
         "options": []

--- a/web/app/components/dashboard/TriggerBuilderModal.vue
+++ b/web/app/components/dashboard/TriggerBuilderModal.vue
@@ -19,6 +19,37 @@
       <!-- Scrollable Content -->
       <div class="flex-1 overflow-y-auto p-6 space-y-8">
         
+        <!-- 0. General Settings -->
+        <div class="space-y-3 p-4 rounded-xl bg-white/[0.02] border border-white/10">
+          <h3 class="font-medium text-white text-sm">General Settings</h3>
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <UFormField label="Name">
+              <UInput v-model="triggerName" placeholder="Trigger name" />
+            </UFormField>
+
+            <UFormField label="Target Channel">
+              <USelect
+                v-if="channelOptions && channelOptions.length > 0"
+                v-model="triggerChannelId"
+                :items="channelOptions"
+                placeholder="Select channel"
+              />
+              <UInput v-else v-model="triggerChannelId" placeholder="Channel ID" />
+            </UFormField>
+
+            <UFormField label="Provider">
+              <USelect v-model="triggerProvider" :items="providerOptions" />
+            </UFormField>
+
+            <UFormField label="Status">
+              <div class="flex items-center justify-between h-9 px-3 rounded-lg bg-white/5 border border-white/10">
+                <span class="text-xs text-gray-300 font-medium">{{ triggerEnabled ? 'Active' : 'Disabled' }}</span>
+                <USwitch v-model="triggerEnabled" />
+              </div>
+            </UFormField>
+          </div>
+        </div>
+
         <!-- 1. Sample Payload -->
         <div class="space-y-3">
           <div class="flex items-center justify-between">
@@ -150,10 +181,23 @@ import EmbedPreview from '~/components/EmbedPreview.vue';
 
 const props = defineProps<{
   trigger: TriggerDocument | null;
+  channelOptions?: { label: string; value: string }[];
 }>();
 
 const isOpen = defineModel<boolean>('open', { default: false });
 const emit = defineEmits(['save']);
+
+// General Settings
+const triggerName = ref("");
+const triggerProvider = ref("webhook");
+const triggerChannelId = ref("");
+const triggerEnabled = ref(true);
+
+const providerOptions = [
+  { label: "Generic Webhook", value: "webhook" },
+  { label: "GitHub", value: "github" },
+  { label: "Twitch", value: "twitch" },
+];
 
 const sampleJson = ref("{\n  \"content\": \"Example Payload\"\n}");
 const jsonError = ref(false);
@@ -232,6 +276,11 @@ function insertField(path: string) {
 // Initialize when opened
 watch(() => isOpen.value, (val) => {
   if (val && props.trigger) {
+    triggerName.value = props.trigger.name || "";
+    triggerProvider.value = props.trigger.provider || "webhook";
+    triggerChannelId.value = props.trigger.channel_id || "";
+    triggerEnabled.value = props.trigger.enabled ?? true;
+
     // Load filters
     try {
       if (props.trigger.filters) {
@@ -368,6 +417,10 @@ const save = async () => {
   }
 
   emit('save', {
+    name: triggerName.value,
+    provider: triggerProvider.value,
+    channel_id: triggerChannelId.value,
+    enabled: triggerEnabled.value,
     filters: Object.keys(finalFilters).length > 0 ? JSON.stringify(finalFilters) : null,
     embed_template: Object.keys(finalTemplate).length > 0 ? JSON.stringify(finalTemplate) : null
   });

--- a/web/app/pages/dashboard/server/[guild_id]/modules/triggers.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/triggers.vue
@@ -322,6 +322,7 @@
   <TriggerBuilderModal
     v-model:open="isBuilderOpen"
     :trigger="activeTriggerForBuild"
+    :channel-options="channelOptions"
     @save="onSaveBuilder"
   />
 </template>
@@ -468,7 +469,7 @@ const openBuilder = (trigger: TriggerDocument) => {
   isBuilderOpen.value = true;
 };
 
-const onSaveBuilder = async (data: { filters: string | null; embed_template: string | null }) => {
+const onSaveBuilder = async (data: Record<string, any>) => {
   if (!activeTriggerForBuild.value) return;
   try {
     await updateTrigger(activeTriggerForBuild.value.$id, data);


### PR DESCRIPTION
## Summary
Resolves #39 by allowing users to edit target Discord channels and trigger configurations via bot slash command and web dashboard.

## Changes
- **Discord Bot**: Added \/triggers edit\ subcommand with optional channel, provider, name, enabled, template, and filter options.
- **Web Dashboard**: Extended \TriggerBuilderModal\ to edit target channel, trigger name, provider, and active status.

Closes #39