### PR TITLE
feat: dashboard module page RBAC

### DIFF
--- a/packages/db/drizzle/0012_new_hiroim.sql
+++ b/packages/db/drizzle/0012_new_hiroim.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "module_access" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+	"guild_id" text NOT NULL,
+	"module_name" text NOT NULL,
+	"role_ids" text[] DEFAULT ARRAY[]::text[] NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "module_access_guild_module_idx" ON "module_access" USING btree ("guild_id","module_name");--> statement-breakpoint
+CREATE INDEX "module_access_guild_id_idx" ON "module_access" USING btree ("guild_id");

--- a/packages/db/drizzle/meta/0012_snapshot.json
+++ b/packages/db/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,3167 @@
+{
+  "id": "4f124b7e-c192-4545-b535-fee73b53477b",
+  "prevId": "e2f481d0-0050-4e5f-b5d5-66301b3a3014",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ai_usage_log": {
+      "name": "ai_usage_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_cost": {
+          "name": "estimated_cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'chat'"
+        },
+        "key_source": {
+          "name": "key_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ai_usage_log_guild_timestamp_idx": {
+          "name": "ai_usage_log_guild_timestamp_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_log_user_timestamp_idx": {
+          "name": "ai_usage_log_user_timestamp_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_usage_log_timestamp_idx": {
+          "name": "ai_usage_log_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.automod_rules": {
+      "name": "automod_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "exempt_roles": {
+          "name": "exempt_roles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "exempt_channels": {
+          "name": "exempt_channels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "cooldown": {
+          "name": "cooldown",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automod_rules_guild_idx": {
+          "name": "automod_rules_guild_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automod_rules_guild_enabled_idx": {
+          "name": "automod_rules_guild_enabled_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automod_rules_guild_trigger_idx": {
+          "name": "automod_rules_guild_trigger_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bot_status": {
+      "name": "bot_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bot_id": {
+          "name": "bot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shard_id": {
+          "name": "shard_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_shards": {
+          "name": "total_shards",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_announcements": {
+      "name": "event_announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_announcements_guild_event_idx": {
+          "name": "event_announcements_guild_event_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.giveaway_entries": {
+      "name": "giveaway_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "giveaway_id": {
+          "name": "giveaway_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entered_at": {
+          "name": "entered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "giveaway_entries_giveaway_user_idx": {
+          "name": "giveaway_entries_giveaway_user_idx",
+          "columns": [
+            {
+              "expression": "giveaway_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "giveaway_entries_giveaway_id_giveaways_id_fk": {
+          "name": "giveaway_entries_giveaway_id_giveaways_id_fk",
+          "tableFrom": "giveaway_entries",
+          "tableTo": "giveaways",
+          "columnsFrom": [
+            "giveaway_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.giveaways": {
+      "name": "giveaways",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prize_kind": {
+          "name": "prize_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prize_value": {
+          "name": "prize_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winner_count": {
+          "name": "winner_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"requiredRoleIds\":[],\"blockedRoleIds\":[]}'::jsonb"
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "winner_ids": {
+          "name": "winner_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'slash'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "giveaways_status_ends_at_idx": {
+          "name": "giveaways_status_ends_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "giveaways_guild_idx": {
+          "name": "giveaways_guild_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "giveaways_message_id_idx": {
+          "name": "giveaways_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guild_configs": {
+      "name": "guild_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_name": {
+          "name": "module_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "guild_configs_guild_module_idx": {
+          "name": "guild_configs_guild_module_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "module_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guild_configs_guild_id_idx": {
+          "name": "guild_configs_guild_id_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "guild_configs_module_enabled_idx": {
+          "name": "guild_configs_module_enabled_idx",
+          "columns": [
+            {
+              "expression": "module_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.logs": {
+      "name": "logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shard_id": {
+          "name": "shard_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "logs_guild_timestamp_idx": {
+          "name": "logs_guild_timestamp_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logs_timestamp_idx": {
+          "name": "logs_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_users": {
+      "name": "milestone_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "char_count": {
+          "name": "char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_milestone": {
+          "name": "last_milestone",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notification_pref": {
+          "name": "notification_pref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "opted_in": {
+          "name": "opted_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "milestone_users_guild_user_idx": {
+          "name": "milestone_users_guild_user_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "milestone_users_guild_chars_idx": {
+          "name": "milestone_users_guild_chars_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "char_count",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.module_access": {
+      "name": "module_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_name": {
+          "name": "module_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_ids": {
+          "name": "role_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "module_access_guild_module_idx": {
+          "name": "module_access_guild_module_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "module_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "module_access_guild_id_idx": {
+          "name": "module_access_guild_id_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.modules": {
+      "name": "modules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "modules_name_idx": {
+          "name": "modules_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_operations": {
+      "name": "music_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "music_operations_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resulting_revision": {
+          "name": "resulting_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "music_operations_guild_operation_idx": {
+          "name": "music_operations_guild_operation_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "music_operations_guild_revision_idx": {
+          "name": "music_operations_guild_revision_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resulting_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_operations_guild_id_music_sessions_guild_id_fk": {
+          "name": "music_operations_guild_id_music_sessions_guild_id_fk",
+          "tableFrom": "music_operations",
+          "tableTo": "music_sessions",
+          "columnsFrom": [
+            "guild_id"
+          ],
+          "columnsTo": [
+            "guild_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_queue_entries": {
+      "name": "music_queue_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_metadata": {
+          "name": "canonical_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "match_source": {
+          "name": "match_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_confidence": {
+          "name": "match_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "music_queue_entries_guild_position_idx": {
+          "name": "music_queue_entries_guild_position_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_queue_entries_guild_id_music_sessions_guild_id_fk": {
+          "name": "music_queue_entries_guild_id_music_sessions_guild_id_fk",
+          "tableFrom": "music_queue_entries",
+          "tableTo": "music_sessions",
+          "columnsFrom": [
+            "guild_id"
+          ],
+          "columnsTo": [
+            "guild_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_sessions": {
+      "name": "music_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_entry_id": {
+          "name": "current_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checkpoint_position_ms": {
+          "name": "checkpoint_position_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "checkpointed_at": {
+          "name": "checkpointed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume": {
+          "name": "volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "repeat_mode": {
+          "name": "repeat_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'off'"
+        },
+        "autoplay": {
+          "name": "autoplay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "assigned_node_id": {
+          "name": "assigned_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "music_sessions_guild_id_unique": {
+          "name": "music_sessions_guild_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "guild_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poll_templates": {
+      "name": "poll_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "duration_hours": {
+          "name": "duration_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 24
+        },
+        "allow_multiselect": {
+          "name": "allow_multiselect",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "poll_templates_guild_id_idx": {
+          "name": "poll_templates_guild_id_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls": {
+      "name": "polls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finalized": {
+          "name": "finalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'slash'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "polls_guild_active_idx": {
+          "name": "polls_guild_active_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "finalized = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "polls_message_id_idx": {
+          "name": "polls_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "polls_template_id_poll_templates_id_fk": {
+          "name": "polls_template_id_poll_templates_id_fk",
+          "tableFrom": "polls",
+          "tableTo": "poll_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recording_tracks": {
+      "name": "recording_tracks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_offset": {
+          "name": "start_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "segments": {
+          "name": "segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recording_tracks_recording_id_idx": {
+          "name": "recording_tracks_recording_id_idx",
+          "columns": [
+            {
+              "expression": "recording_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recording_tracks_recording_id_recordings_id_fk": {
+          "name": "recording_tracks_recording_id_recordings_id_fk",
+          "tableFrom": "recording_tracks",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recordings": {
+      "name": "recordings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mixed_file_id": {
+          "name": "mixed_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bitrate": {
+          "name": "bitrate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "multitrack": {
+          "name": "multitrack",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "participants": {
+          "name": "participants",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recordings_guild_started_at_idx": {
+          "name": "recordings_guild_started_at_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recordings_started_at_idx": {
+          "name": "recordings_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reminders": {
+      "name": "reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reminder": {
+          "name": "reminder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remind_at": {
+          "name": "remind_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_url": {
+          "name": "message_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quoted_content": {
+          "name": "quoted_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "reminders_user_id_idx": {
+          "name": "reminders_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reminders_pending_remind_at_idx": {
+          "name": "reminders_pending_remind_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remind_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.servers": {
+      "name": "servers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_count": {
+          "name": "member_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ping": {
+          "name": "ping",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shard_id": {
+          "name": "shard_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checked": {
+          "name": "last_checked",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_link": {
+          "name": "invite_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "premium": {
+          "name": "premium",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "admin_user_ids": {
+          "name": "admin_user_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "dashboard_role_ids": {
+          "name": "dashboard_role_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "servers_guild_id_idx": {
+          "name": "servers_guild_id_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "servers_owner_id_idx": {
+          "name": "servers_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_data": {
+          "name": "embed_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_roles": {
+          "name": "allowed_roles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "is_template": {
+          "name": "is_template",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tags_guild_name_idx": {
+          "name": "tags_guild_name_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_guild_idx": {
+          "name": "tags_guild_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_guild_template_idx": {
+          "name": "tags_guild_template_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_template",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.temp_voice_channels": {
+      "name": "temp_voice_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lobby_channel_id": {
+          "name": "lobby_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "temp_voice_channels_channel_id_idx": {
+          "name": "temp_voice_channels_channel_id_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "temp_voice_channels_guild_idx": {
+          "name": "temp_voice_channels_guild_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "temp_voice_channels_guild_owner_idx": {
+          "name": "temp_voice_channels_guild_owner_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ticket_messages": {
+      "name": "ticket_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "ticket_messages_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "transcript_id": {
+          "name": "transcript_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_message_id": {
+          "name": "discord_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_tag": {
+          "name": "author_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_avatar_url": {
+          "name": "author_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_is_bot": {
+          "name": "author_is_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "embeds": {
+          "name": "embeds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ticket_messages_transcript_created_idx": {
+          "name": "ticket_messages_transcript_created_idx",
+          "columns": [
+            {
+              "expression": "transcript_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ticket_messages_transcript_id_ticket_transcripts_id_fk": {
+          "name": "ticket_messages_transcript_id_ticket_transcripts_id_fk",
+          "tableFrom": "ticket_messages",
+          "tableTo": "ticket_transcripts",
+          "columnsFrom": [
+            "transcript_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ticket_transcripts": {
+      "name": "ticket_transcripts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_name": {
+          "name": "thread_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opener_id": {
+          "name": "opener_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by_id": {
+          "name": "claimed_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_id": {
+          "name": "closed_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_ids": {
+          "name": "participant_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_skipped_attachments": {
+          "name": "has_skipped_attachments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mentions": {
+          "name": "mentions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ticket_transcripts_guild_closed_idx": {
+          "name": "ticket_transcripts_guild_closed_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ticket_transcripts_opener_idx": {
+          "name": "ticket_transcripts_opener_idx",
+          "columns": [
+            {
+              "expression": "opener_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ticket_transcripts_expires_idx": {
+          "name": "ticket_transcripts_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "expires_at IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ticket_transcripts_thread_id_unique": {
+          "name": "ticket_transcripts_thread_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "thread_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.triggers": {
+      "name": "triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embed_template": {
+          "name": "embed_template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filters": {
+          "name": "filters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "triggers_secret_idx": {
+          "name": "triggers_secret_idx",
+          "columns": [
+            {
+              "expression": "secret",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "triggers_guild_name_idx": {
+          "name": "triggers_guild_name_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "triggers_guild_idx": {
+          "name": "triggers_guild_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "triggers_guild_enabled_idx": {
+          "name": "triggers_guild_enabled_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.xp_users": {
+      "name": "xp_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xp": {
+          "name": "xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "char_count": {
+          "name": "char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_xp_gain_at": {
+          "name": "last_xp_gain_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_pref": {
+          "name": "notification_pref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "opted_in": {
+          "name": "opted_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hidden_from_leaderboard": {
+          "name": "hidden_from_leaderboard",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "xp_users_guild_user_idx": {
+          "name": "xp_users_guild_user_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "xp_users_guild_xp_idx": {
+          "name": "xp_users_guild_xp_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "xp",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1787094294861,
       "tag": "0011_eminent_slipstream",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1787182124110,
+      "tag": "0012_new_hiroim",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -18,6 +18,7 @@ export * from "./repositories/poll-templates";
 export * from "./repositories/polls";
 export * from "./repositories/giveaways";
 export * from "./repositories/event-announcements";
+export * from "./repositories/module-access";
 export * from "./repositories/music";
 export * from "./repositories/xp";
 export * from "./rank-cards";

--- a/packages/db/src/repositories/module-access.ts
+++ b/packages/db/src/repositories/module-access.ts
@@ -1,0 +1,62 @@
+/**
+ * ModuleAccessRepository — per-(guild, module) dashboard RBAC grants.
+ *
+ * Mirrors GuildConfigRepository's keying convention: one row per
+ * (guildId, moduleName), upserted on write. A module with no row has no
+ * non-admin role grant.
+ */
+import { and, eq } from "drizzle-orm";
+import type { Database } from "../client";
+import { moduleAccess } from "../schema";
+
+export class ModuleAccessRepository {
+  constructor(private db: Database) {}
+
+  async getRoleIds(guildId: string, moduleName: string): Promise<string[]> {
+    const rows = await this.db
+      .select({ roleIds: moduleAccess.roleIds })
+      .from(moduleAccess)
+      .where(
+        and(
+          eq(moduleAccess.guildId, guildId),
+          eq(moduleAccess.moduleName, moduleName.toLowerCase()),
+        ),
+      )
+      .limit(1);
+    return rows[0]?.roleIds ?? [];
+  }
+
+  async setRoleIds(
+    guildId: string,
+    moduleName: string,
+    roleIds: string[],
+  ): Promise<void> {
+    const name = moduleName.toLowerCase();
+    await this.db
+      .insert(moduleAccess)
+      .values({ guildId, moduleName: name, roleIds })
+      .onConflictDoUpdate({
+        target: [moduleAccess.guildId, moduleAccess.moduleName],
+        set: { roleIds, updatedAt: new Date() },
+      });
+  }
+
+  /**
+   * Every module's role grant for a guild, keyed by module name. Modules
+   * with no row (never configured) are simply absent from the result.
+   */
+  async getAllForGuild(guildId: string): Promise<Record<string, string[]>> {
+    const rows = await this.db
+      .select({
+        moduleName: moduleAccess.moduleName,
+        roleIds: moduleAccess.roleIds,
+      })
+      .from(moduleAccess)
+      .where(eq(moduleAccess.guildId, guildId));
+    const result: Record<string, string[]> = {};
+    for (const row of rows) {
+      result[row.moduleName] = row.roleIds;
+    }
+    return result;
+  }
+}

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -250,6 +250,42 @@ export const guildConfigs = pgTable(
 export type GuildConfig = typeof guildConfigs.$inferSelect;
 export type NewGuildConfig = typeof guildConfigs.$inferInsert;
 
+// ── module_access ────────────────────────────────────────────────────────
+// Per-(guild, module) dashboard RBAC grant. A role in `role_ids` may access
+// and edit that module's dashboard config page without being a full admin
+// (servers.admin_user_ids). Absent row = no non-admin role has access.
+
+export const moduleAccess = pgTable(
+  "module_access",
+  {
+    id: text("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()::text`),
+    guildId: text("guild_id").notNull(),
+    moduleName: text("module_name").notNull(),
+    roleIds: text("role_ids")
+      .array()
+      .notNull()
+      .default(sql`ARRAY[]::text[]`),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => ({
+    byGuildModule: uniqueIndex("module_access_guild_module_idx").on(
+      t.guildId,
+      t.moduleName,
+    ),
+    byGuild: index("module_access_guild_id_idx").on(t.guildId),
+  }),
+);
+
+export type ModuleAccess = typeof moduleAccess.$inferSelect;
+export type NewModuleAccess = typeof moduleAccess.$inferInsert;
+
 // ── bot_status ────────────────────────────────────────────────────────────
 // Per-shard heartbeat. Document ID was `shard-<n>` in Appwrite; we preserve
 // that as the primary key so cross-shard upserts remain stable.

--- a/web/app/components/dashboard/ModuleAccessSection.vue
+++ b/web/app/components/dashboard/ModuleAccessSection.vue
@@ -1,0 +1,107 @@
+<template>
+  <section v-if="state.isServerOwnerOrAdmin">
+    <div class="mb-4">
+      <h2 class="text-lg font-bold text-white">Module Access</h2>
+      <p class="text-sm text-gray-400">
+        Grant specific Discord roles access to just this module's settings
+        page, without making them a full dashboard admin.
+      </p>
+    </div>
+
+    <UCard :ui="{ root: 'border border-white/10 bg-white/[0.02]' }">
+      <div class="space-y-4">
+        <div v-if="state.rolesLoading || loadingGrant" class="flex items-center gap-2 py-3">
+          <UIcon
+            name="i-lucide-loader-circle"
+            class="w-4 h-4 animate-spin text-indigo-400"
+          />
+          <span class="text-sm text-gray-400">Loading server roles from Discord...</span>
+        </div>
+
+        <USelectMenu
+          v-else-if="roleOptions.length > 0"
+          v-model="selectedRoles"
+          :items="roleOptions"
+          value-key="value"
+          multiple
+          placeholder="Select roles..."
+          class="w-full"
+          @update:model-value="dirty = true"
+        />
+        <p v-else class="text-sm text-gray-500 py-2">
+          No roles available. Make sure the bot is in this server.
+        </p>
+
+        <div class="flex items-center justify-between pt-2 border-t border-white/[0.06]">
+          <p class="text-xs text-gray-500">
+            {{ selectedRoles.length }} role{{ selectedRoles.length !== 1 ? "s" : "" }} selected
+          </p>
+          <UButton
+            color="primary"
+            size="sm"
+            :loading="saving"
+            :disabled="!dirty || loadingGrant"
+            @click="handleSave"
+          >
+            Save Access
+          </UButton>
+        </div>
+      </div>
+    </UCard>
+  </section>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  guildId: string;
+  moduleName: string;
+}>();
+
+const { state, loadRoles, roleOptions } = useServerSettings(props.guildId);
+const toast = useToast();
+
+const selectedRoles = ref<string[]>([]);
+const dirty = ref(false);
+const saving = ref(false);
+const loadingGrant = ref(true);
+
+onMounted(async () => {
+  if (!state.value.isServerOwnerOrAdmin) return;
+  await loadRoles();
+  try {
+    const current = await $fetch<{ roleIds: string[] }>(
+      `/api/module-access/${encodeURIComponent(props.guildId)}/${encodeURIComponent(props.moduleName)}`,
+    );
+    selectedRoles.value = current.roleIds;
+  } catch (error) {
+    console.error("Error loading module access:", error);
+  } finally {
+    loadingGrant.value = false;
+  }
+});
+
+const handleSave = async () => {
+  saving.value = true;
+  try {
+    await $fetch(
+      `/api/module-access/${encodeURIComponent(props.guildId)}/${encodeURIComponent(props.moduleName)}`,
+      { method: "PUT", body: { roleIds: selectedRoles.value } },
+    );
+    dirty.value = false;
+    toast.add({
+      title: "Module Access Updated",
+      description: `Roles with access to the ${props.moduleName} settings page have been updated.`,
+      color: "success",
+    });
+  } catch (error) {
+    console.error("Error saving module access:", error);
+    toast.add({
+      title: "Error",
+      description: "Failed to update module access.",
+      color: "error",
+    });
+  } finally {
+    saving.value = false;
+  }
+};
+</script>

--- a/web/app/composables/useServerSettings.ts
+++ b/web/app/composables/useServerSettings.ts
@@ -50,6 +50,10 @@ export interface ServerSettingsState {
   unauthorized: boolean;
   dashboardRoleIds: string[];
   isServerOwnerOrAdmin: boolean;
+  /** Module names this user may access when NOT a full admin; null when
+   *  isServerOwnerOrAdmin is true (no restriction) or access hasn't been
+   *  resolved yet. */
+  accessibleModules: string[] | null;
 }
 
 
@@ -69,6 +73,7 @@ export function useServerSettings(guildId: string) {
       unauthorized: false,
       dashboardRoleIds: [],
       isServerOwnerOrAdmin: false,
+      accessibleModules: null,
     }),
   );
 
@@ -368,6 +373,26 @@ export function useServerSettings(guildId: string) {
         return;
       } catch {
         // Not a Discord admin and no matching dashboard role.
+      }
+
+      // Not a manager and no whole-dashboard promotion — check for
+      // module-scoped access before giving up.
+      try {
+        const access = await $fetch<{ modules: string[] }>(
+          "/api/servers/module-access",
+          { params: { guild_id: guildId } },
+        );
+        if (access.modules.length > 0) {
+          state.value.accessibleModules = access.modules;
+          state.value.guild = {
+            id: serverDoc.guild_id,
+            name: serverDoc.name,
+            icon: serverDoc.icon,
+          };
+          return;
+        }
+      } catch {
+        // No module-scoped access either.
       }
 
       state.value.unauthorized = true;

--- a/web/app/pages/dashboard/server/[guild_id].vue
+++ b/web/app/pages/dashboard/server/[guild_id].vue
@@ -22,6 +22,20 @@
       <UButton to="/dashboard" color="primary">Back to Dashboard</UButton>
     </div>
 
+    <!-- Module-scoped user hitting a page outside their grant -->
+    <div v-else-if="state.guild && !canAccessActiveTab" class="text-center py-20">
+      <UIcon
+        name="i-heroicons-lock-closed"
+        class="w-16 h-16 text-red-500 mx-auto mb-4"
+      />
+      <h1 class="text-3xl font-bold mb-2">Access Denied</h1>
+      <p class="text-gray-500 mb-8">
+        You don't have access to this page. Ask a server admin to grant your
+        role access to this module.
+      </p>
+      <UButton :to="`${basePath}/modules`" color="primary">Back to Dashboard</UButton>
+    </div>
+
     <!-- Content: Child Pages -->
     <NuxtPage v-else-if="state.guild" />
   </div>
@@ -48,28 +62,37 @@ const activeTab = computed(() => {
   return "modules";
 });
 
+const canAccessActiveTab = computed(() => {
+  if (state.value.accessibleModules === null) return true;
+  if (["logs", "modules", "identity"].includes(activeTab.value)) return false;
+  return state.value.accessibleModules.includes(activeTab.value);
+});
+
 // Sidebar tab definitions — route-based, grouped by category
 const sidebarTabs = computed(() => {
-  const staticTabs = [
-    {
-      id: "logs",
-      label: "Server Logs",
-      icon: "i-lucide-file-text",
-      to: `${basePath}/logs`,
-    },
-    {
-      id: "modules",
-      label: "Modules",
-      icon: "i-lucide-layout-grid",
-      to: `${basePath}/modules`,
-    },
-    {
-      id: "identity",
-      label: "Bot Identity",
-      icon: "i-lucide-bot",
-      to: `${basePath}/identity`,
-    },
-  ];
+  const staticTabs =
+    state.value.accessibleModules === null
+      ? [
+          {
+            id: "logs",
+            label: "Server Logs",
+            icon: "i-lucide-file-text",
+            to: `${basePath}/logs`,
+          },
+          {
+            id: "modules",
+            label: "Modules",
+            icon: "i-lucide-layout-grid",
+            to: `${basePath}/modules`,
+          },
+          {
+            id: "identity",
+            label: "Bot Identity",
+            icon: "i-lucide-bot",
+            to: `${basePath}/identity`,
+          },
+        ]
+      : [];
 
   const moduleTabs: Array<{
     id: string;
@@ -82,6 +105,11 @@ const sidebarTabs = computed(() => {
   for (const cat of MODULE_CATEGORIES) {
     const catModules = state.value.modules
       .filter((m) => hasModuleSettings(m.name) && getModuleDisplay(m).category === cat.key)
+      .filter(
+        (m) =>
+          state.value.accessibleModules === null ||
+          state.value.accessibleModules.includes(m.name.toLowerCase()),
+      )
       .sort((a, b) =>
         getModuleDisplay(a).displayName.localeCompare(getModuleDisplay(b).displayName),
       );

--- a/web/app/pages/dashboard/server/[guild_id].vue
+++ b/web/app/pages/dashboard/server/[guild_id].vue
@@ -33,7 +33,7 @@
         You don't have access to this page. Ask a server admin to grant your
         role access to this module.
       </p>
-      <UButton :to="`${basePath}/modules`" color="primary">Back to Dashboard</UButton>
+      <UButton :to="accessDeniedBackTo" color="primary">Back to Dashboard</UButton>
     </div>
 
     <!-- Content: Child Pages -->
@@ -67,6 +67,15 @@ const canAccessActiveTab = computed(() => {
   if (["logs", "modules", "identity"].includes(activeTab.value)) return false;
   return state.value.accessibleModules.includes(activeTab.value);
 });
+
+// Access-denied escape hatch: admins land on the modules grid; module-scoped
+// users would just bounce off that same grid (it's admin-only), so send them
+// to the first module they actually have access to.
+const accessDeniedBackTo = computed(() =>
+  state.value.accessibleModules === null
+    ? `${basePath}/modules`
+    : `${basePath}/modules/${state.value.accessibleModules[0]}`,
+);
 
 // Sidebar tab definitions — route-based, grouped by category
 const sidebarTabs = computed(() => {

--- a/web/app/pages/dashboard/server/[guild_id].vue
+++ b/web/app/pages/dashboard/server/[guild_id].vue
@@ -70,12 +70,18 @@ const canAccessActiveTab = computed(() => {
 
 // Access-denied escape hatch: admins land on the modules grid; module-scoped
 // users would just bounce off that same grid (it's admin-only), so send them
-// to the first module they actually have access to.
-const accessDeniedBackTo = computed(() =>
-  state.value.accessibleModules === null
-    ? `${basePath}/modules`
-    : `${basePath}/modules/${state.value.accessibleModules[0]}`,
-);
+// to the first module they actually have access to. Not every module has a
+// real settings page, so prefer the first accessible module that does;
+// fall back to the plain first entry if none of them do.
+const accessDeniedBackTo = computed(() => {
+  if (state.value.accessibleModules === null) {
+    return `${basePath}/modules`;
+  }
+  const target =
+    state.value.accessibleModules.find((m) => hasModuleSettings(m)) ??
+    state.value.accessibleModules[0];
+  return `${basePath}/modules/${target}`;
+});
 
 // Sidebar tab definitions — route-based, grouped by category
 const sidebarTabs = computed(() => {

--- a/web/app/pages/dashboard/server/[guild_id]/modules/ai.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/ai.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="space-y-8">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="ai" />
+
     <!-- Header -->
     <div class="flex items-center justify-between">
       <div class="flex items-center gap-4">

--- a/web/app/pages/dashboard/server/[guild_id]/modules/alerts.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/alerts.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="p-6 lg:p-8 space-y-6">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="alerts" />
+
     <!-- Header -->
     <div class="flex items-center gap-4">
       <NuxtLink

--- a/web/app/pages/dashboard/server/[guild_id]/modules/antiraid.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/antiraid.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="p-6 lg:p-8 space-y-6">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="antiraid" />
+
     <!-- Header -->
     <div class="flex items-center gap-4">
       <NuxtLink

--- a/web/app/pages/dashboard/server/[guild_id]/modules/automod.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/automod.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="p-6 lg:p-8 space-y-6">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="automod" />
+
     <!-- ── Header ── -->
     <div class="flex items-center gap-4">
       <NuxtLink

--- a/web/app/pages/dashboard/server/[guild_id]/modules/embeds.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/embeds.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="p-6 lg:p-8 space-y-6">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="embeds" />
+
     <!-- Header -->
     <div class="flex items-center justify-between">
       <div>

--- a/web/app/pages/dashboard/server/[guild_id]/modules/events.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/events.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="p-6 lg:p-8 space-y-6">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="events" />
+
     <!-- Header -->
     <div class="flex items-center gap-4">
       <NuxtLink

--- a/web/app/pages/dashboard/server/[guild_id]/modules/giveaways.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/giveaways.vue
@@ -109,6 +109,8 @@ onMounted(() => {
 
 <template>
   <div class="p-6 lg:p-8 space-y-6">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="giveaways" />
+
     <!-- Header -->
     <div class="flex items-center gap-4">
       <NuxtLink

--- a/web/app/pages/dashboard/server/[guild_id]/modules/logging.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/logging.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="p-6 lg:p-8 space-y-6">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="logging" />
+
     <!-- Header -->
     <div class="flex items-center gap-4">
       <NuxtLink

--- a/web/app/pages/dashboard/server/[guild_id]/modules/moderation.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/moderation.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="p-6 lg:p-8 space-y-6">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="moderation" />
+
     <!-- Header -->
     <div class="flex items-center gap-4">
       <NuxtLink

--- a/web/app/pages/dashboard/server/[guild_id]/modules/music.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/music.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="p-6 lg:p-8 space-y-6">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="music" />
+
     <!-- Header -->
     <div class="flex items-center gap-4">
       <NuxtLink

--- a/web/app/pages/dashboard/server/[guild_id]/modules/polls.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/polls.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="p-6 lg:p-8 space-y-6">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="polls" />
+
     <!-- Header -->
     <div class="flex items-center gap-4">
       <NuxtLink

--- a/web/app/pages/dashboard/server/[guild_id]/modules/polls.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/polls.vue
@@ -238,7 +238,7 @@
               <p class="text-sm font-medium text-white flex-1">{{ poll.question }}</p>
               <UBadge color="neutral" variant="soft" size="xs">{{ poll.source }}</UBadge>
               <UButton
-                v-if="state.isServerOwnerOrAdmin"
+                v-if="state.isServerOwnerOrAdmin || state.accessibleModules?.includes('polls')"
                 color="error"
                 variant="ghost"
                 size="xs"

--- a/web/app/pages/dashboard/server/[guild_id]/modules/reaction-roles.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/reaction-roles.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="p-6 lg:p-8 space-y-6">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="reaction-roles" />
+
     <!-- Header -->
     <div class="flex items-center gap-4">
       <NuxtLink

--- a/web/app/pages/dashboard/server/[guild_id]/modules/recording.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/recording.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="p-6 lg:p-8 space-y-6">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="recording" />
+
     <!-- Header -->
     <div class="flex items-center gap-4">
       <NuxtLink

--- a/web/app/pages/dashboard/server/[guild_id]/modules/tags.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/tags.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="p-6 lg:p-8 space-y-6">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="tags" />
+
     <!-- Header -->
     <div class="flex items-center justify-between mb-2">
       <div>

--- a/web/app/pages/dashboard/server/[guild_id]/modules/tempvoice.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/tempvoice.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="p-6 lg:p-8 space-y-6">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="tempvoice" />
+
     <!-- Header -->
     <div class="flex items-center gap-4">
       <NuxtLink

--- a/web/app/pages/dashboard/server/[guild_id]/modules/tickets.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/tickets.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="p-6 lg:p-8 space-y-6">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="tickets" />
+
     <!-- Header -->
     <div class="flex items-center gap-4">
       <NuxtLink

--- a/web/app/pages/dashboard/server/[guild_id]/modules/triggers.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/triggers.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="p-6 lg:p-8 space-y-6">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="triggers" />
+
     <!-- Header -->
     <div class="flex items-center gap-4">
       <NuxtLink

--- a/web/app/pages/dashboard/server/[guild_id]/modules/verification.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/verification.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="p-6 lg:p-8 space-y-6">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="verification" />
+
     <!-- Header -->
     <div class="flex items-center gap-4">
       <NuxtLink

--- a/web/app/pages/dashboard/server/[guild_id]/modules/welcome.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/welcome.vue
@@ -1,4 +1,7 @@
 <template>
+  <div class="p-6 lg:p-8">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="welcome" />
+  </div>
   <!-- Full-bleed: no padding wrapper so the editor fills edge-to-edge -->
   <WelcomeEditor
     :guild-id="guildId"

--- a/web/app/pages/dashboard/server/[guild_id]/modules/xp.vue
+++ b/web/app/pages/dashboard/server/[guild_id]/modules/xp.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="p-6 lg:p-8 space-y-8 w-full">
+    <DashboardModuleAccessSection :guild-id="guildId" module-name="xp" />
+
     <!-- Header -->
     <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4 border-b border-white/10 pb-6">
       <div class="flex items-center gap-4">

--- a/web/server/api/ai/usage.get.ts
+++ b/web/server/api/ai/usage.get.ts
@@ -1,6 +1,6 @@
 /** List AI usage logs for a guild. */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
@@ -14,7 +14,7 @@ export default defineEventHandler(async (event) => {
 
   // Usage rows carry per-user Discord IDs and cost data — restrict to
   // managers of the guild (previously this endpoint had no auth at all).
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "ai");
 
   const limit = Math.min(Number(query.limit) || 100, 250);
 

--- a/web/server/api/automod/[rule_id].delete.ts
+++ b/web/server/api/automod/[rule_id].delete.ts
@@ -4,7 +4,7 @@
  * Delete an automod rule. Caller must manage the rule's guild.
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const ruleId = getRouterParam(event, "rule_id");
@@ -25,7 +25,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, statusMessage: "Rule not found" });
   }
 
-  await requireGuildManager(event, existing.guild_id);
+  await requireModuleAccess(event, existing.guild_id, "automod");
 
   try {
     await repos.automod.delete(ruleId);

--- a/web/server/api/automod/[rule_id].put.ts
+++ b/web/server/api/automod/[rule_id].put.ts
@@ -9,7 +9,7 @@
  *                 exempt_roles, exempt_channels, cooldown }
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const ruleId = getRouterParam(event, "rule_id");
@@ -30,7 +30,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, statusMessage: "Rule not found" });
   }
 
-  await requireGuildManager(event, existing.guild_id);
+  await requireModuleAccess(event, existing.guild_id, "automod");
 
   const body = await readBody(event);
   try {

--- a/web/server/api/automod/index.get.ts
+++ b/web/server/api/automod/index.get.ts
@@ -6,7 +6,7 @@
  * leak cross-tenant to any authenticated user.
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
@@ -18,7 +18,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "automod");
 
   const repos = getRepos();
   if (!repos) {

--- a/web/server/api/automod/index.post.ts
+++ b/web/server/api/automod/index.post.ts
@@ -8,7 +8,7 @@
  * exempt_channels, cooldown, created_by.
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event);
@@ -19,7 +19,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  const { userId } = await requireGuildManager(event, body.guild_id);
+  const { userId } = await requireModuleAccess(event, body.guild_id, "automod");
 
   const repos = getRepos();
   if (!repos) {

--- a/web/server/api/discord/channels.get.ts
+++ b/web/server/api/discord/channels.get.ts
@@ -5,7 +5,7 @@
  * Query params:
  *   - guild_id: The Discord guild ID
  */
-import { requireGuildManager } from "../../utils/session";
+import { getAccessibleModules } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig();
@@ -19,7 +19,13 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireGuildManager(event, guildId);
+  const accessibleModules = await getAccessibleModules(event, guildId);
+  if (accessibleModules !== "all" && accessibleModules.length === 0) {
+    throw createError({
+      statusCode: 403,
+      statusMessage: "You don't manage this server.",
+    });
+  }
 
   const botToken = config.discordBotToken as string;
   if (!botToken) {

--- a/web/server/api/discord/roles.get.ts
+++ b/web/server/api/discord/roles.get.ts
@@ -5,7 +5,7 @@
  * Query params:
  *   - guild_id: The Discord guild ID
  */
-import { requireGuildManager } from "../../utils/session";
+import { getAccessibleModules } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig();
@@ -19,7 +19,13 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireGuildManager(event, guildId);
+  const accessibleModules = await getAccessibleModules(event, guildId);
+  if (accessibleModules !== "all" && accessibleModules.length === 0) {
+    throw createError({
+      statusCode: 403,
+      statusMessage: "You don't manage this server.",
+    });
+  }
 
   const botToken = config.discordBotToken as string;
   if (!botToken) {

--- a/web/server/api/discord/scheduled-events.get.ts
+++ b/web/server/api/discord/scheduled-events.get.ts
@@ -4,7 +4,7 @@
  *
  * Query params: guild_id
  */
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig();
@@ -18,7 +18,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "events");
 
   const botToken = config.discordBotToken as string;
   if (!botToken) {

--- a/web/server/api/discord/scheduled-events.post.ts
+++ b/web/server/api/discord/scheduled-events.post.ts
@@ -17,7 +17,7 @@
  * scheduled_start_time/scheduled_end_time are ISO8601 strings.
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig();
@@ -40,7 +40,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "events");
 
   const botToken = config.discordBotToken as string;
   if (!botToken) {

--- a/web/server/api/discord/scheduled-events/[event_id].delete.ts
+++ b/web/server/api/discord/scheduled-events/[event_id].delete.ts
@@ -2,7 +2,7 @@
  * Delete a Discord scheduled event. No announcement is posted (see spec).
  * Query params: guild_id
  */
-import { requireGuildManager } from "../../../utils/session";
+import { requireModuleAccess } from "../../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig();
@@ -17,7 +17,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "events");
 
   const botToken = config.discordBotToken as string;
   if (!botToken) {

--- a/web/server/api/discord/scheduled-events/[event_id].patch.ts
+++ b/web/server/api/discord/scheduled-events/[event_id].patch.ts
@@ -4,7 +4,7 @@
  * Body: { guild_id, name?, description?, scheduled_start_time?,
  *         scheduled_end_time?, location? }
  */
-import { requireGuildManager } from "../../../utils/session";
+import { requireModuleAccess } from "../../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig();
@@ -19,7 +19,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "events");
 
   const botToken = config.discordBotToken as string;
   if (!botToken) {

--- a/web/server/api/discord/send-embed.post.ts
+++ b/web/server/api/discord/send-embed.post.ts
@@ -24,7 +24,12 @@ export default defineEventHandler(async (event) => {
 
   // Sending with the bot token is a privileged action — restrict to managers
   // of the target guild.
-  await requireModuleAccess(event, guild_id, "embeds");
+  try {
+    await requireModuleAccess(event, guild_id, "embeds");
+  } catch (err: any) {
+    if (err?.statusCode !== 403) throw err;
+    await requireModuleAccess(event, guild_id, "tags");
+  }
 
   // Validate embed has at least title or description or fields or components
   const hasContent =
@@ -50,7 +55,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Confirm the target channel actually belongs to the authorized guild.
-  // requireGuildManager only proves the caller manages `guild_id`; without
+  // requireModuleAccess only proves the caller manages `guild_id`; without
   // this check a manager of one guild could still address a channel in a
   // different guild the bot happens to be in.
   let channelGuildId: string | undefined;

--- a/web/server/api/discord/send-embed.post.ts
+++ b/web/server/api/discord/send-embed.post.ts
@@ -2,7 +2,7 @@
  * Server-side endpoint to send an embed to a specific channel.
  * Uses the Discord bot token to send messages directly.
  */
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig();
@@ -24,7 +24,7 @@ export default defineEventHandler(async (event) => {
 
   // Sending with the bot token is a privileged action — restrict to managers
   // of the target guild.
-  await requireGuildManager(event, guild_id);
+  await requireModuleAccess(event, guild_id, "embeds");
 
   // Validate embed has at least title or description or fields or components
   const hasContent =

--- a/web/server/api/events/[channel].get.ts
+++ b/web/server/api/events/[channel].get.ts
@@ -31,7 +31,7 @@ import {
 import {
   requireAuthedUserId,
   requireBotAdmin,
-  requireGuildManager,
+  requireModuleAccess,
 } from "../../utils/session";
 
 const HEARTBEAT_MS = 25_000;
@@ -71,7 +71,7 @@ export default defineEventHandler(async (event) => {
         statusMessage: "Missing guild_id query parameter.",
       });
     }
-    await requireGuildManager(event, guildId);
+    await requireModuleAccess(event, guildId, "events");
     scopedGuildId = guildId;
   } else {
     await requireAuthedUserId(event);

--- a/web/server/api/events/[channel].get.ts
+++ b/web/server/api/events/[channel].get.ts
@@ -12,9 +12,10 @@
  * across every guild, so it is additionally restricted to bot admins.
  * The `poll-votes` channel carries per-guild data (including which Discord
  * user voted) across every guild the bot serves, so it requires a
- * `guild_id` query param and guild-manager access, and every published
- * payload is filtered server-side to that guild before being written to
- * the stream — it is never a fleet-wide firehose to the client.
+ * `guild_id` query param and `polls` module access (the channel feeds the
+ * polls dashboard page's live vote counts), and every published payload is
+ * filtered server-side to that guild before being written to the stream —
+ * it is never a fleet-wide firehose to the client.
  *
  * Heartbeat comments every 25s keep the connection alive through proxy
  * idle timeouts. The client (EventSource) reconnects automatically if
@@ -71,7 +72,7 @@ export default defineEventHandler(async (event) => {
         statusMessage: "Missing guild_id query parameter.",
       });
     }
-    await requireModuleAccess(event, guildId, "events");
+    await requireModuleAccess(event, guildId, "polls");
     scopedGuildId = guildId;
   } else {
     await requireAuthedUserId(event);

--- a/web/server/api/giveaways/cancel.post.ts
+++ b/web/server/api/giveaways/cancel.post.ts
@@ -7,7 +7,7 @@
  * Body: { guild_id, id }
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 import { buildGiveawayComponentsJson, buildGiveawayEmbedJson } from "./_embed";
 import type { PrizeKind } from "./_embed";
 
@@ -21,7 +21,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: "Missing required fields: guild_id, id." });
   }
 
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "giveaways");
 
   const repos = getRepos();
   if (!repos) {

--- a/web/server/api/giveaways/create.post.ts
+++ b/web/server/api/giveaways/create.post.ts
@@ -65,7 +65,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Verify the channel belongs to the authorized guild — same check every
-  // other write route in this codebase performs (requireGuildManager only
+  // other write route in this codebase performs (requireModuleAccess only
   // proves the caller manages guild_id, not that channel_id lives inside it).
   let channelGuildId: string | undefined;
   try {

--- a/web/server/api/giveaways/create.post.ts
+++ b/web/server/api/giveaways/create.post.ts
@@ -9,7 +9,7 @@
  *         min_server_age_days? }
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 import { buildGiveawayComponentsJson, buildGiveawayEmbedJson } from "./_embed";
 import type { PrizeKind } from "./_embed";
 
@@ -52,7 +52,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: "winner_count must be an integer between 1 and 50." });
   }
 
-  const identity = await requireGuildManager(event, guildId);
+  const identity = await requireModuleAccess(event, guildId, "giveaways");
 
   const repos = getRepos();
   if (!repos) {

--- a/web/server/api/giveaways/list.get.ts
+++ b/web/server/api/giveaways/list.get.ts
@@ -2,7 +2,7 @@
  * List giveaways for a guild, most recent first, with live entrant counts.
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
@@ -12,7 +12,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: "Missing guild_id query parameter." });
   }
 
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "giveaways");
 
   const repos = getRepos();
   if (!repos) {

--- a/web/server/api/giveaways/update.post.ts
+++ b/web/server/api/giveaways/update.post.ts
@@ -16,7 +16,7 @@
  * string, and treating that as an explicit clear would destroy the code.
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 import { buildGiveawayComponentsJson, buildGiveawayEmbedJson } from "./_embed";
 import type { PrizeKind } from "./_embed";
 
@@ -34,7 +34,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: "Missing required fields: guild_id, id." });
   }
 
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "giveaways");
 
   const repos = getRepos();
   if (!repos) {

--- a/web/server/api/guild-configs/[guild_id]/[module].get.ts
+++ b/web/server/api/guild-configs/[guild_id]/[module].get.ts
@@ -5,7 +5,7 @@
  * Convenience endpoint for dashboard pages editing a specific module.
  */
 import { getRepos } from "../../../utils/db";
-import { requireGuildManager } from "../../../utils/session";
+import { requireModuleAccess } from "../../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const guildId = getRouterParam(event, "guild_id");
@@ -20,7 +20,7 @@ export default defineEventHandler(async (event) => {
   // Module settings can contain secrets (e.g. the AI provider API key), so
   // this must be restricted to managers of the specific guild rather than any
   // authenticated user.
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, moduleName);
 
   const repos = getRepos();
   if (!repos) {

--- a/web/server/api/guild-configs/[guild_id]/[module].put.ts
+++ b/web/server/api/guild-configs/[guild_id]/[module].put.ts
@@ -10,7 +10,7 @@
  */
 import { validateWelcomeImageElements } from "@modus/db/welcome-images";
 import { getRepos } from "../../../utils/db";
-import { requireGuildManager } from "../../../utils/session";
+import { requireModuleAccess } from "../../../utils/session";
 import { deleteR2Object, extractWelcomeBgKey } from "../../../utils/r2";
 
 export default defineEventHandler(async (event) => {
@@ -34,7 +34,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, moduleName);
 
   const body = await readBody<{
     enabled?: boolean;

--- a/web/server/api/guild-configs/index.get.ts
+++ b/web/server/api/guild-configs/index.get.ts
@@ -6,7 +6,7 @@
  * state and rehydrate settings editors.
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { getAccessibleModules } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
@@ -18,9 +18,10 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  // Module settings can carry secrets (e.g. the AI module's aiApiKey), so
-  // this must be scoped to managers of the guild — not any logged-in user.
-  await requireGuildManager(event, guildId);
+  // Module settings can carry secrets (e.g. the AI module's aiApiKey), so a
+  // module-scoped caller must only see rows for modules they're actually
+  // granted — not the full guild dump a manager gets.
+  const accessibleModules = await getAccessibleModules(event, guildId);
 
   const repos = getRepos();
   if (!repos) {
@@ -31,7 +32,9 @@ export default defineEventHandler(async (event) => {
   }
 
   try {
-    return await repos.guildConfigs.listByGuild(guildId);
+    const rows = await repos.guildConfigs.listByGuild(guildId);
+    if (accessibleModules === "all") return rows;
+    return rows.filter((r) => accessibleModules.includes(r.moduleName));
   } catch (error: any) {
     console.error(
       `[GuildConfigs API] list failed for ${guildId}:`,

--- a/web/server/api/module-access/[guild_id]/[module].get.ts
+++ b/web/server/api/module-access/[guild_id]/[module].get.ts
@@ -1,0 +1,33 @@
+/**
+ * GET /api/module-access/:guild_id/:module
+ *
+ * The Discord role IDs currently granted access to this module's dashboard
+ * config page. Admin-only — module-scoped users can use their module's
+ * page but can't see or change who else has access to it.
+ */
+import { getRepos } from "../../../utils/db";
+import { requireGuildManager } from "../../../utils/session";
+
+export default defineEventHandler(async (event) => {
+  const guildId = getRouterParam(event, "guild_id");
+  const moduleName = getRouterParam(event, "module");
+  if (!guildId || !moduleName) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Missing guild_id or module route param.",
+    });
+  }
+
+  await requireGuildManager(event, guildId);
+
+  const repos = getRepos();
+  if (!repos) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: "Database unavailable (NUXT_DATABASE_URL not set).",
+    });
+  }
+
+  const roleIds = await repos.moduleAccess.getRoleIds(guildId, moduleName);
+  return { roleIds };
+});

--- a/web/server/api/module-access/[guild_id]/[module].put.ts
+++ b/web/server/api/module-access/[guild_id]/[module].put.ts
@@ -22,7 +22,10 @@ export default defineEventHandler(async (event) => {
   await requireGuildManager(event, guildId);
 
   const body = await readBody<{ roleIds?: string[] }>(event);
-  if (!Array.isArray(body?.roleIds)) {
+  if (
+    !Array.isArray(body?.roleIds) ||
+    !body.roleIds.every((r: unknown) => typeof r === "string")
+  ) {
     throw createError({
       statusCode: 400,
       statusMessage: "Missing required field: roleIds (array).",

--- a/web/server/api/module-access/[guild_id]/[module].put.ts
+++ b/web/server/api/module-access/[guild_id]/[module].put.ts
@@ -1,0 +1,42 @@
+/**
+ * PUT /api/module-access/:guild_id/:module
+ *
+ * Replace the Discord role IDs granted access to this module's dashboard
+ * config page. Admin-only.
+ *
+ * Body: { roleIds: string[] }
+ */
+import { getRepos } from "../../../utils/db";
+import { requireGuildManager } from "../../../utils/session";
+
+export default defineEventHandler(async (event) => {
+  const guildId = getRouterParam(event, "guild_id");
+  const moduleName = getRouterParam(event, "module");
+  if (!guildId || !moduleName) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Missing guild_id or module route param.",
+    });
+  }
+
+  await requireGuildManager(event, guildId);
+
+  const body = await readBody<{ roleIds?: string[] }>(event);
+  if (!Array.isArray(body?.roleIds)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Missing required field: roleIds (array).",
+    });
+  }
+
+  const repos = getRepos();
+  if (!repos) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: "Database unavailable (NUXT_DATABASE_URL not set).",
+    });
+  }
+
+  await repos.moduleAccess.setRoleIds(guildId, moduleName, body.roleIds);
+  return { success: true };
+});

--- a/web/server/api/music/action.post.ts
+++ b/web/server/api/music/action.post.ts
@@ -1,7 +1,7 @@
 // Proxy: POST /api/music/action
 // Forwards control actions (skip, pause, resume, stop, shuffle, play, volume, remove, reorder, search)
 // to the bot's HTTP API
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event);
@@ -14,7 +14,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireGuildManager(event, guild_id);
+  await requireModuleAccess(event, guild_id, "music");
 
   const validActions = [
     "skip",

--- a/web/server/api/music/lyrics.get.ts
+++ b/web/server/api/music/lyrics.get.ts
@@ -1,5 +1,5 @@
 // Proxy: GET /api/music/lyrics?guild_id=...&query=...
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
@@ -13,7 +13,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "music");
 
   const config = useRuntimeConfig();
   const botUrl = (config.public.botUrl as string) || "http://localhost:3005";

--- a/web/server/api/music/prequeue.get.ts
+++ b/web/server/api/music/prequeue.get.ts
@@ -1,6 +1,6 @@
 // Proxy: GET /api/music/prequeue?guild_id=...
 // Fetches the pre-queue from the bot's HTTP API
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, message: "Missing guild_id" });
   }
 
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "music");
 
   const config = useRuntimeConfig();
   const botUrl = (config.public.botUrl as string) || "http://localhost:3005";

--- a/web/server/api/music/state.get.ts
+++ b/web/server/api/music/state.get.ts
@@ -1,6 +1,6 @@
 // Proxy: GET /api/music/state?guild_id=...
 // Fetches the current player state from the bot's HTTP API
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: "Missing guild_id" });
   }
 
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "music");
 
   const config = useRuntimeConfig();
   const botUrl = (config.public.botUrl as string) || "http://localhost:3005";

--- a/web/server/api/polls/end.post.ts
+++ b/web/server/api/polls/end.post.ts
@@ -34,7 +34,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Verify the channel belongs to the authorized guild — same check every
-  // other poll-writing route in this feature performs (requireGuildManager
+  // other poll-writing route in this feature performs (requireModuleAccess
   // only proves the caller manages guild_id, not that channel_id lives
   // inside it).
   let channelGuildId: string | undefined;

--- a/web/server/api/polls/end.post.ts
+++ b/web/server/api/polls/end.post.ts
@@ -5,7 +5,7 @@
  * Body: { guild_id, channel_id, message_id }
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig();
@@ -23,7 +23,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "polls");
 
   const botToken = config.discordBotToken as string;
   if (!botToken) {

--- a/web/server/api/polls/list.get.ts
+++ b/web/server/api/polls/list.get.ts
@@ -8,7 +8,7 @@
  * that the caller has any relationship to `guild_id`).
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 interface DiscordPollAnswerCount {
   id: number;
@@ -32,7 +32,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "polls");
 
   const repos = getRepos();
   if (!repos) {

--- a/web/server/api/polls/send.post.ts
+++ b/web/server/api/polls/send.post.ts
@@ -108,7 +108,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Verify the channel belongs to the authorized guild (same check as
-  // send-embed.post.ts — requireGuildManager only proves the caller manages
+  // send-embed.post.ts — requireModuleAccess only proves the caller manages
   // guild_id, not that channel_id lives inside it).
   let channelGuildId: string | undefined;
   try {

--- a/web/server/api/polls/send.post.ts
+++ b/web/server/api/polls/send.post.ts
@@ -9,7 +9,7 @@
  * fall back to the template's saved values but can still be overridden.
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig();
@@ -29,7 +29,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  const identity = await requireGuildManager(event, guildId);
+  const identity = await requireModuleAccess(event, guildId, "polls");
 
   const repos = getRepos();
   if (!repos) {

--- a/web/server/api/polls/templates/create.post.ts
+++ b/web/server/api/polls/templates/create.post.ts
@@ -5,7 +5,7 @@
  *         allow_multiselect, created_by? }
  */
 import { getRepos } from "../../../utils/db";
-import { requireGuildManager } from "../../../utils/session";
+import { requireModuleAccess } from "../../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event);
@@ -50,7 +50,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  const identity = await requireGuildManager(event, body.guild_id);
+  const identity = await requireModuleAccess(event, body.guild_id, "polls");
 
   const repos = getRepos();
   if (!repos) {

--- a/web/server/api/polls/templates/delete.post.ts
+++ b/web/server/api/polls/templates/delete.post.ts
@@ -1,6 +1,6 @@
 /** Delete a poll template. Body: { template_id } */
 import { getRepos } from "../../../utils/db";
-import { requireGuildManager } from "../../../utils/session";
+import { requireModuleAccess } from "../../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event);
@@ -24,7 +24,7 @@ export default defineEventHandler(async (event) => {
   if (!existing) {
     throw createError({ statusCode: 404, statusMessage: "Template not found." });
   }
-  await requireGuildManager(event, existing.guildId);
+  await requireModuleAccess(event, existing.guildId, "polls");
 
   try {
     await repos.pollTemplates.delete(body.template_id);

--- a/web/server/api/polls/templates/list.get.ts
+++ b/web/server/api/polls/templates/list.get.ts
@@ -1,6 +1,6 @@
 /** List poll templates for a guild. */
 import { getRepos } from "../../../utils/db";
-import { requireGuildManager } from "../../../utils/session";
+import { requireModuleAccess } from "../../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
@@ -13,7 +13,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "polls");
 
   const repos = getRepos();
   if (!repos) {

--- a/web/server/api/polls/templates/update.put.ts
+++ b/web/server/api/polls/templates/update.put.ts
@@ -1,6 +1,6 @@
 /** Update a poll template. Body: { template_id, data: {...partial fields} } */
 import { getRepos } from "../../../utils/db";
-import { requireGuildManager } from "../../../utils/session";
+import { requireModuleAccess } from "../../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event);
@@ -69,7 +69,7 @@ export default defineEventHandler(async (event) => {
   if (!existing) {
     throw createError({ statusCode: 404, statusMessage: "Template not found." });
   }
-  await requireGuildManager(event, existing.guildId);
+  await requireModuleAccess(event, existing.guildId, "polls");
 
   try {
     const template = await repos.pollTemplates.update(body.template_id, {

--- a/web/server/api/recordings/delete-file.post.ts
+++ b/web/server/api/recordings/delete-file.post.ts
@@ -16,7 +16,7 @@ import {
   guildIdFromRecordingKey,
   looksLikeR2Key,
 } from "../../utils/r2";
-import { requireAuthedUserId, requireGuildManager } from "../../utils/session";
+import { requireAuthedUserId, requireModuleAccess } from "../../utils/session";
 
 const ANNOUNCE_PREFIX = "announce/";
 
@@ -51,7 +51,7 @@ export default defineEventHandler(async (event) => {
         statusMessage: "fileId is not a recording object key.",
       });
     }
-    await requireGuildManager(event, ownerGuildId);
+    await requireModuleAccess(event, ownerGuildId, "recording");
   }
 
   if (!getR2()) {

--- a/web/server/api/recordings/delete.post.ts
+++ b/web/server/api/recordings/delete.post.ts
@@ -8,7 +8,7 @@
  */
 import { deleteR2Object, getR2, looksLikeR2Key } from "../../utils/r2";
 import { getRecordingRepo } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 async function removeFile(fileId: string) {
   if (getR2() && looksLikeR2Key(fileId)) {
@@ -55,7 +55,7 @@ export default defineEventHandler(async (event) => {
 
     // Authorize against the recording's true owning guild — never trust the
     // guild_id from the body alone for the permission decision.
-    await requireGuildManager(event, existing.guild_id);
+    await requireModuleAccess(event, existing.guild_id, "recording");
 
     const tracks = await repo.listTracks(recordingId);
 

--- a/web/server/api/recordings/list.get.ts
+++ b/web/server/api/recordings/list.get.ts
@@ -1,6 +1,6 @@
 /** List recordings for a guild. */
 import { getRecordingRepo } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
@@ -12,7 +12,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "recording");
 
   const repo = getRecordingRepo();
   if (!repo) {

--- a/web/server/api/recordings/stream.get.ts
+++ b/web/server/api/recordings/stream.get.ts
@@ -12,7 +12,7 @@ import {
   looksLikeR2Key,
   presignGet,
 } from "../../utils/r2";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
@@ -43,7 +43,7 @@ export default defineEventHandler(async (event) => {
       statusMessage: "file_id is not a recording object key.",
     });
   }
-  await requireGuildManager(event, ownerGuildId);
+  await requireModuleAccess(event, ownerGuildId, "recording");
 
   if (!getR2()) {
     throw createError({

--- a/web/server/api/recordings/tracks.get.ts
+++ b/web/server/api/recordings/tracks.get.ts
@@ -1,6 +1,6 @@
 /** List tracks for a recording. */
 import { getRecordingRepo } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
@@ -26,7 +26,7 @@ export default defineEventHandler(async (event) => {
   if (!recording) {
     throw createError({ statusCode: 404, statusMessage: "Recording not found." });
   }
-  await requireGuildManager(event, recording.guild_id);
+  await requireModuleAccess(event, recording.guild_id, "recording");
 
   try {
     return await repo.listTracks(recordingId);

--- a/web/server/api/servers/join.post.ts
+++ b/web/server/api/servers/join.post.ts
@@ -13,6 +13,7 @@ import {
   getResolvedDiscordId,
   requireAuthedUserId,
 } from "../../utils/session";
+import { fetchGuildMemberRoleIds } from "../../utils/discord";
 import { canManageGuild } from "#shared/discord-permissions";
 
 export default defineEventHandler(async (event) => {
@@ -77,18 +78,8 @@ export default defineEventHandler(async (event) => {
     if (dashboardRoles.length > 0) {
       const discordUid = await getResolvedDiscordId(event);
       if (discordUid) {
-        const botToken = config.discordBotToken as string;
-        if (botToken) {
-          const member: any = await $fetch(
-            `https://discord.com/api/v10/guilds/${guild_id}/members/${discordUid}`,
-            { headers: { Authorization: `Bot ${botToken}` } },
-          ).catch(() => null);
-          if (member?.roles) {
-            hasDashboardRole = member.roles.some((r: string) =>
-              dashboardRoles.includes(r),
-            );
-          }
-        }
+        const memberRoleIds = await fetchGuildMemberRoleIds(guild_id, discordUid);
+        hasDashboardRole = memberRoleIds.some((r) => dashboardRoles.includes(r));
       }
     }
 

--- a/web/server/api/servers/module-access.get.ts
+++ b/web/server/api/servers/module-access.get.ts
@@ -1,0 +1,29 @@
+/**
+ * GET /api/servers/module-access?guild_id=...
+ *
+ * The current caller's accessible-module set for this guild, when they are
+ * NOT a full manager (the dashboard's checkPermissions flow only calls this
+ * after the admin_user_ids / dashboard_role_ids checks have already
+ * failed). Backs the module-scoped dashboard access branch.
+ */
+import { requireAuthedUserId, getAccessibleModules } from "../../utils/session";
+
+export default defineEventHandler(async (event) => {
+  await requireAuthedUserId(event);
+
+  const query = getQuery(event);
+  const guildId = query.guild_id as string;
+  if (!guildId) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Missing guild_id query parameter.",
+    });
+  }
+
+  const result = await getAccessibleModules(event, guildId);
+  // "all" means the caller is actually a manager — shouldn't happen from
+  // this call site, but if a role changes mid-session, report no
+  // module-scoped grants rather than fabricating a full module list; the
+  // client's earlier admin/join checks are the correct path for that case.
+  return { modules: result === "all" ? [] : result };
+});

--- a/web/server/api/tags/create.post.ts
+++ b/web/server/api/tags/create.post.ts
@@ -38,7 +38,12 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireModuleAccess(event, guild_id, "tags");
+  try {
+    await requireModuleAccess(event, guild_id, "tags");
+  } catch (err: any) {
+    if (err?.statusCode !== 403) throw err;
+    await requireModuleAccess(event, guild_id, "embeds");
+  }
 
   const slug = slugify(name);
   if (!slug) {

--- a/web/server/api/tags/create.post.ts
+++ b/web/server/api/tags/create.post.ts
@@ -5,7 +5,7 @@
  *   - guild_id, name, content?, embed_data?, allowed_roles?, created_by?
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 function slugify(name: string): string {
   return String(name)
@@ -38,7 +38,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireGuildManager(event, guild_id);
+  await requireModuleAccess(event, guild_id, "tags");
 
   const slug = slugify(name);
   if (!slug) {

--- a/web/server/api/tags/delete.post.ts
+++ b/web/server/api/tags/delete.post.ts
@@ -4,7 +4,7 @@
  * POST body: { tag_id, guild_id }
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event);
@@ -33,7 +33,7 @@ export default defineEventHandler(async (event) => {
   if (!existing) {
     throw createError({ statusCode: 404, statusMessage: "Tag not found." });
   }
-  await requireGuildManager(event, existing.guild_id);
+  await requireModuleAccess(event, existing.guild_id, "tags");
 
   try {
     await repos.tags.delete(tag_id);

--- a/web/server/api/tags/delete.post.ts
+++ b/web/server/api/tags/delete.post.ts
@@ -33,7 +33,12 @@ export default defineEventHandler(async (event) => {
   if (!existing) {
     throw createError({ statusCode: 404, statusMessage: "Tag not found." });
   }
-  await requireModuleAccess(event, existing.guild_id, "tags");
+  try {
+    await requireModuleAccess(event, existing.guild_id, "tags");
+  } catch (err: any) {
+    if (err?.statusCode !== 403) throw err;
+    await requireModuleAccess(event, existing.guild_id, "embeds");
+  }
 
   try {
     await repos.tags.delete(tag_id);

--- a/web/server/api/tags/list.get.ts
+++ b/web/server/api/tags/list.get.ts
@@ -2,7 +2,7 @@
  * List tags for a guild.
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
@@ -15,7 +15,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "tags");
 
   const repos = getRepos();
   if (!repos) {

--- a/web/server/api/tags/list.get.ts
+++ b/web/server/api/tags/list.get.ts
@@ -15,7 +15,12 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireModuleAccess(event, guildId, "tags");
+  try {
+    await requireModuleAccess(event, guildId, "tags");
+  } catch (err: any) {
+    if (err?.statusCode !== 403) throw err;
+    await requireModuleAccess(event, guildId, "embeds");
+  }
 
   const repos = getRepos();
   if (!repos) {

--- a/web/server/api/tags/update.put.ts
+++ b/web/server/api/tags/update.put.ts
@@ -69,7 +69,12 @@ export default defineEventHandler(async (event) => {
   if (!existing) {
     throw createError({ statusCode: 404, statusMessage: "Tag not found." });
   }
-  await requireModuleAccess(event, existing.guild_id, "tags");
+  try {
+    await requireModuleAccess(event, existing.guild_id, "tags");
+  } catch (err: any) {
+    if (err?.statusCode !== 403) throw err;
+    await requireModuleAccess(event, existing.guild_id, "embeds");
+  }
 
   try {
     await repos.tags.update(tag_id, normalized);

--- a/web/server/api/tags/update.put.ts
+++ b/web/server/api/tags/update.put.ts
@@ -5,7 +5,7 @@
  *   - tag_id, guild_id, name?, content?, embed_data?, allowed_roles?
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event);
@@ -69,7 +69,7 @@ export default defineEventHandler(async (event) => {
   if (!existing) {
     throw createError({ statusCode: 404, statusMessage: "Tag not found." });
   }
-  await requireGuildManager(event, existing.guild_id);
+  await requireModuleAccess(event, existing.guild_id, "tags");
 
   try {
     await repos.tags.update(tag_id, normalized);

--- a/web/server/api/tickets/transcripts/list.get.ts
+++ b/web/server/api/tickets/transcripts/list.get.ts
@@ -3,7 +3,7 @@
  *
  * Returns the 25 most-recent transcripts for a guild. Guild-admin only.
  */
-import { requireGuildManager } from "../../../utils/session";
+import { requireModuleAccess } from "../../../utils/session";
 import { getRepos } from "../../../utils/db";
 
 export default defineEventHandler(async (event) => {
@@ -16,7 +16,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "tickets");
 
   const repos = getRepos();
   if (!repos) {

--- a/web/server/api/triggers/create.post.ts
+++ b/web/server/api/triggers/create.post.ts
@@ -6,7 +6,7 @@
  *   - embed_template?, filters?, created_by? (optional)
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event);
@@ -25,7 +25,7 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await requireGuildManager(event, body.guild_id);
+  await requireModuleAccess(event, body.guild_id, "triggers");
 
   const input = {
     guild_id: body.guild_id,

--- a/web/server/api/triggers/delete.post.ts
+++ b/web/server/api/triggers/delete.post.ts
@@ -4,7 +4,7 @@
  * Body: { trigger_id }
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event);
@@ -29,7 +29,7 @@ export default defineEventHandler(async (event) => {
   if (!existing) {
     throw createError({ statusCode: 404, statusMessage: "Trigger not found." });
   }
-  await requireGuildManager(event, existing.guild_id);
+  await requireModuleAccess(event, existing.guild_id, "triggers");
 
   try {
     await repos.triggers.delete(body.trigger_id);

--- a/web/server/api/triggers/list.get.ts
+++ b/web/server/api/triggers/list.get.ts
@@ -1,6 +1,6 @@
 /** List triggers for a guild. */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
@@ -15,7 +15,7 @@ export default defineEventHandler(async (event) => {
 
   // Trigger docs include the webhook secret, so this must be gated to guild
   // managers.
-  await requireGuildManager(event, guildId);
+  await requireModuleAccess(event, guildId, "triggers");
 
   const repos = getRepos();
   if (!repos) {

--- a/web/server/api/triggers/update.put.ts
+++ b/web/server/api/triggers/update.put.ts
@@ -4,7 +4,7 @@
  * Body: { trigger_id, data: { ... } }
  */
 import { getRepos } from "../../utils/db";
-import { requireGuildManager } from "../../utils/session";
+import { requireModuleAccess } from "../../utils/session";
 
 export default defineEventHandler(async (event) => {
   const body = await readBody(event);
@@ -29,7 +29,7 @@ export default defineEventHandler(async (event) => {
   if (!existing) {
     throw createError({ statusCode: 404, statusMessage: "Trigger not found." });
   }
-  await requireGuildManager(event, existing.guild_id);
+  await requireModuleAccess(event, existing.guild_id, "triggers");
 
   try {
     await repos.triggers.update(body.trigger_id, body.data);

--- a/web/server/utils/db.ts
+++ b/web/server/utils/db.ts
@@ -11,6 +11,7 @@ import {
   GuildConfigRepository,
   ServerRepository,
   ModuleRepository,
+  ModuleAccessRepository,
   BotStatusRepository,
   LogRepository,
   MilestoneUserRepository,
@@ -33,6 +34,7 @@ export interface Repos {
   db: Database;
   recordings: RecordingRepository;
   guildConfigs: GuildConfigRepository;
+  moduleAccess: ModuleAccessRepository;
   servers: ServerRepository;
   modules: ModuleRepository;
   botStatus: BotStatusRepository;
@@ -67,6 +69,7 @@ export function getRepos(): Repos | null {
       db,
       recordings: new RecordingRepository(db),
       guildConfigs: new GuildConfigRepository(db),
+      moduleAccess: new ModuleAccessRepository(db),
       servers: new ServerRepository(db),
       modules: new ModuleRepository(db),
       botStatus: new BotStatusRepository(db),

--- a/web/server/utils/discord.ts
+++ b/web/server/utils/discord.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared bot-token Discord REST helpers used by session/module-access
+ * guards. Requires DISCORD_BOT_TOKEN (config.discordBotToken); returns an
+ * empty list rather than throwing when the token is missing or the lookup
+ * fails (404 = user not in guild, 403 = bot not in guild) — callers treat
+ * "no roles" as "no elevated access", which is the safe default.
+ */
+export async function fetchGuildMemberRoleIds(
+  guildId: string,
+  discordUid: string,
+): Promise<string[]> {
+  const config = useRuntimeConfig();
+  const botToken = config.discordBotToken as string;
+  if (!botToken) return [];
+  try {
+    const member: any = await $fetch(
+      `https://discord.com/api/v10/guilds/${guildId}/members/${discordUid}`,
+      { headers: { Authorization: `Bot ${botToken}` } },
+    );
+    return Array.isArray(member?.roles) ? member.roles : [];
+  } catch {
+    return [];
+  }
+}

--- a/web/server/utils/session.ts
+++ b/web/server/utils/session.ts
@@ -14,6 +14,7 @@
  */
 import type { H3Event } from "h3";
 import { getRepos } from "./db";
+import { fetchGuildMemberRoleIds } from "./discord";
 
 // ── Session shape ────────────────────────────────────────────────────────
 
@@ -138,6 +139,82 @@ export async function requireGuildManager(
     });
   }
   return identity;
+}
+
+/**
+ * Require the caller to either manage the guild (requireGuildManager) OR
+ * have a Discord role listed in that module's `module_access` grant.
+ * Lets a server owner delegate one module's config page to staff without
+ * making them a full dashboard admin. 403 when neither condition holds.
+ */
+export async function requireModuleAccess(
+  event: H3Event,
+  guildId: string,
+  moduleName: string,
+): Promise<AuthedIdentity> {
+  try {
+    return await requireGuildManager(event, guildId);
+  } catch (err: any) {
+    if (err?.statusCode !== 403) throw err;
+  }
+
+  const identity = await requireAuthedUserId(event);
+  const repos = getRepos();
+  if (!repos) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: "Database unavailable (NUXT_DATABASE_URL not set).",
+    });
+  }
+
+  const roleIds = await repos.moduleAccess.getRoleIds(
+    guildId,
+    moduleName.toLowerCase(),
+  );
+  if (roleIds.length > 0) {
+    const memberRoleIds = await fetchGuildMemberRoleIds(guildId, identity.userId);
+    if (memberRoleIds.some((r) => roleIds.includes(r))) {
+      return identity;
+    }
+  }
+
+  throw createError({
+    statusCode: 403,
+    statusMessage: "You don't have access to this module.",
+  });
+}
+
+/**
+ * Every module the caller may access in this guild: `"all"` for a full
+ * manager (requireGuildManager passes), otherwise the list of module names
+ * whose `module_access` grant intersects the caller's live Discord roles.
+ * Used to filter the dashboard sidebar and the bulk guild-configs read.
+ */
+export async function getAccessibleModules(
+  event: H3Event,
+  guildId: string,
+): Promise<"all" | string[]> {
+  try {
+    await requireGuildManager(event, guildId);
+    return "all";
+  } catch (err: any) {
+    if (err?.statusCode !== 403) throw err;
+  }
+
+  const identity = await requireAuthedUserId(event);
+  const repos = getRepos();
+  if (!repos) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: "Database unavailable (NUXT_DATABASE_URL not set).",
+    });
+  }
+
+  const grants = await repos.moduleAccess.getAllForGuild(guildId);
+  const memberRoleIds = await fetchGuildMemberRoleIds(guildId, identity.userId);
+  return Object.entries(grants)
+    .filter(([, roleIds]) => roleIds.some((r) => memberRoleIds.includes(r)))
+    .map(([moduleName]) => moduleName);
 }
 
 /** Return the Discord UID of the caller, or null when unauthenticated. */


### PR DESCRIPTION
## Summary

Closes #62.

Lets a server owner grant a Discord role access to a single dashboard module's config page (e.g. a DJ role to just the music page), without making that role a full admin. Coexists with the existing whole-dashboard `admin_user_ids`/`dashboard_role_ids` mechanism, which is unchanged.

- New `module_access` table (`guild_id`, `module_name`, `role_ids`) + `ModuleAccessRepository`.
- `requireModuleAccess`/`getAccessibleModules` server-side guards — a superset of the existing `requireGuildManager` that also honors a matching module grant. ~41 API routes migrated from admin-only to module-scoped-or-admin, covering every module's settings + its data-management actions (tickets, polls, music, events, giveaways, automod, tags, triggers, recordings).
- Client-side dashboard gate gains a third "partial access" branch (module-scoped users are never promoted into `admin_user_ids`), sidebar filtered to granted modules only, direct-URL access to ungranted pages blocked.
- `ModuleAccessSection` component wired into every module's settings page — lets an admin manage that module's role grant via new `/api/module-access/*` routes.

## Design docs

Spec and implementation plan are local-only (`docs/` is gitignored in this repo) — not included in this PR, but available in the branch's working tree if useful for review context.

## Known follow-ups (deliberately out of scope for this PR)

- The `/dashboard` server picker only lists guilds a user owns or admins — a module-scoped-only user currently needs a direct URL from an admin to reach their granted guild's dashboard.
- Discord member-role lookups (`fetchGuildMemberRoleIds`) are uncached; under Discord API rate-limiting this can present to a module-scoped user as a transient "Access Denied" rather than a clear error.
- Not verified in a live browser: `welcome.vue`'s new access-management card sits above the page's deliberately full-bleed editor — no live Postgres/Redis/Discord-OAuth stack was available in the environment this branch was built in to check the layout visually.

## Test plan

No test runner is wired up in this repo (per CLAUDE.md) — verification was `pnpm run build` in both `packages/db` and `web` (clean) plus manual code-trace review at every implementation step. Suggested manual QA before merge:

- [ ] Create a test Discord role, grant it `module_access` for one module (e.g. music) via the new "Module Access" card on that module's settings page (as the server owner/admin).
- [ ] As a non-admin member with that role: confirm the dashboard loads, the sidebar shows only that module's tab, settings can be viewed and edited, and the module's other dashboard actions (e.g. music skip/queue) work.
- [ ] As that same user: confirm direct navigation to any other module or to Server Logs/Modules/Bot Identity shows "Access Denied".
- [ ] Revoke the role's grant (as the owner) and confirm the user loses access on their next dashboard load (no lingering promotion).
- [ ] Spot-check the `welcome.vue` page's layout with the new access card as a full admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)